### PR TITLE
add public key endpoint, example service, extend playground

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -66,4 +66,15 @@ lazy val service = project
     ),
   )
 
-
+lazy val backendExample = project
+  .in(file("modules/backend-example"))
+  .dependsOn(backendClient)
+  .settings(
+    publish / skip := true,
+    name := "lucuma-sso-backend-example",
+    libraryDependencies ++= Seq(
+      "org.http4s" %% "http4s-ember-client" % "0.21.8",
+      "org.http4s" %% "http4s-ember-server" % "0.21.8",
+      "org.slf4j"  %  "slf4j-simple"        % "1.7.30",
+    )
+  )

--- a/modules/backend-example/src/main/scala/Config.scala
+++ b/modules/backend-example/src/main/scala/Config.scala
@@ -1,3 +1,6 @@
+// Copyright (c) 2016-2020 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
 package lucuma.sso.example
 
 import org.http4s.Uri

--- a/modules/backend-example/src/main/scala/Config.scala
+++ b/modules/backend-example/src/main/scala/Config.scala
@@ -1,0 +1,36 @@
+package lucuma.sso.example
+
+import org.http4s.Uri
+import org.http4s.Uri.Host
+import org.http4s.Uri.Scheme
+import org.http4s.Uri.RegName
+import org.http4s.implicits._
+import org.http4s.Uri.Authority
+
+case class Config(
+  host:    Host,
+  port:    Int,
+  scheme:  Scheme,
+  ssoRoot: Uri,
+) {
+
+  def uri: Uri =
+    Uri(
+      scheme    = Some(scheme),
+      authority = Some(Authority(host = host, port = Some(port)))
+    )
+
+}
+
+object Config {
+
+  val Local: Config =
+    Config(
+      host = RegName("local.lucuma.xyz"),
+      port = 8082,
+      scheme = Scheme.http,
+      ssoRoot = uri"http://local.lucuma.xyz:8080"
+    )
+
+}
+

--- a/modules/backend-example/src/main/scala/Main.scala
+++ b/modules/backend-example/src/main/scala/Main.scala
@@ -1,0 +1,76 @@
+package lucuma.sso.example
+
+import cats._
+import cats.effect._
+import cats.syntax.all._
+import io.chrisdavenport.log4cats.Logger
+import io.chrisdavenport.log4cats.slf4j.Slf4jLogger
+import java.security.PublicKey
+import lucuma.core.model.User
+import lucuma.sso.client.SsoMiddleware
+import lucuma.sso.client.util.GpgPublicKeyReader
+import org.http4s._
+import org.http4s.dsl.Http4sDsl
+import org.http4s.ember.client.EmberClientBuilder
+import org.http4s.ember.server.EmberServerBuilder
+import org.http4s.implicits._
+import org.http4s.server.middleware.CORS
+import org.http4s.server.middleware.Logger.{ httpRoutes => log }
+import org.http4s.server.Server
+
+object Main extends IOApp {
+
+  implicit val logger: Logger[IO] =
+    Slf4jLogger.getLoggerFromName("lucuma-sso-example")
+
+  def serverResource[F[_]: Concurrent: ContextShift: Timer](
+    port: Int,
+    app:  HttpApp[F]
+  ): Resource[F, Server[F]] =
+    EmberServerBuilder
+      .default[F]
+      .withHost("0.0.0.0")
+      .withHttpApp(app)
+      .withPort(port)
+      .build
+
+  def routes[F[_]: Defer: Applicative]: AuthedRoutes[User, F] = {
+    object dsl extends Http4sDsl[F]; import dsl._
+    AuthedRoutes.of[User, F] {
+      case GET -> Root / "echo" / greeting as user =>
+        Ok(s"$greeting ${user.displayName}")
+    }
+  }
+
+  def fetchSsoPublicKey[F[_]: Concurrent: Timer: ContextShift](ssoRoot: Uri): F[PublicKey] =
+    EmberClientBuilder.default[F].build.use { client =>
+      implicit val decoder = GpgPublicKeyReader.entityDecoder[F]
+      client.expect[PublicKey](ssoRoot / "api" / "v1" / "public-key")
+    }
+
+  def serverMiddleware[F[_]: Concurrent: Logger](
+    pubKey: PublicKey)
+  : AuthedRoutes[User, F] => HttpRoutes[F] =
+    SsoMiddleware(pubKey) andThen // this adds a check for the Authorization header
+    CORS.httpRoutes[F]    andThen // this is needed by some browsers
+    log[F](                       // log what we're doing
+      logHeaders        = true,
+      logBody           = false,
+      redactHeadersWhen = _ => false
+    )
+
+  def runF[F[_]: Concurrent: Timer: ContextShift: Logger](cfg: Config) =
+    for {
+      pub <- fetchSsoPublicKey(cfg.ssoRoot)
+      app  = serverMiddleware(pub).apply(routes[F]).orNotFound
+      a   <- serverResource(cfg.port, app).use(_ => Concurrent[F].never[ExitCode])
+    } yield a
+
+  def run(args: List[String]): IO[ExitCode] = {
+    val cfg = Config.Local
+    IO(println(s"My URI is ${cfg.uri}"))     *>
+    IO(println(s"   SSO is ${cfg.ssoRoot}")) *>
+    runF[IO](cfg)
+  }
+
+}

--- a/modules/backend-example/src/main/scala/Main.scala
+++ b/modules/backend-example/src/main/scala/Main.scala
@@ -1,3 +1,6 @@
+// Copyright (c) 2016-2020 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
 package lucuma.sso.example
 
 import cats._

--- a/modules/service/src/main/scala/Main.scala
+++ b/modules/service/src/main/scala/Main.scala
@@ -119,7 +119,8 @@ object FMain {
           orcid     = orcid,
           jwtWriter = config.ssoJwtWriter,
           publicUri = config.publicUri,
-          cookies   = CookieService[F](config.cookieDomain, config.scheme === Scheme.https)
+          cookies   = CookieService[F](config.cookieDomain, config.scheme === Scheme.https),
+          publicKey = config.publicKey,
         )
       } .map(ServerMiddleware(config))
 

--- a/modules/service/src/test/scala/CorsSuite.scala
+++ b/modules/service/src/test/scala/CorsSuite.scala
@@ -15,6 +15,7 @@ object CorsSuite extends SsoSuite {
         jwtWriter = null,
         publicUri = uri"http://unused",
         cookies   = null,
+        publicKey = null,
       )
     )
 

--- a/modules/service/src/test/scala/simulator/SsoSimulator.scala
+++ b/modules/service/src/test/scala/simulator/SsoSimulator.scala
@@ -29,7 +29,8 @@ object SsoSimulator {
           orcid     = OrcidService(OrcidConfig.orcidHost(Environment.Production), "unused", "unused", sim.client),
           jwtWriter = config.ssoJwtWriter,
           publicUri = config.publicUri,
-          cookies   = CookieService[F]("lucuma.xyz", false)
+          cookies   = CookieService[F]("lucuma.xyz", false),
+          publicKey = config.publicKey,
         ), config.ssoJwtReader)
     }
   }

--- a/playground/playground.html
+++ b/playground/playground.html
@@ -2,7 +2,9 @@
   <title>LUCUMA-SSO LOCAL PLAYGROUND</title>
   <script>
 
-    var ssoRootUri = "http://local.lucuma.xyz:8080"
+    var ssoRootUri     = "http://local.lucuma.xyz:8080"
+    var exampleRootUri = "http://local.lucuma.xyz:8082"
+
     var jwt = null
 
     function parseJwt(token) {
@@ -15,11 +17,10 @@
     }
 
     function authAsGuest() {
+      document.getElementById("greeting").innerHTML = ""
       var xhttp = new XMLHttpRequest()
-      xhttp.onreadystatechange = function() {
-        if (this.readyState == 4) {
-          setJwt(xhttp.responseText);
-        }
+      xhttp.onload = function() {
+        setJwt(xhttp.responseText);
       }
       xhttp.open("POST", ssoRootUri + "/api/v1/auth-as-guest", true);
       xhttp.withCredentials = true
@@ -31,11 +32,10 @@
     }
 
     function logout() {
+      document.getElementById("greeting").innerHTML = ""
       var xhttp = new XMLHttpRequest()
-      xhttp.onreadystatechange = function() {
-        if (this.readyState == 4) {
-          init()
-        }
+      xhttp.onload = function() {
+        init()
       }
       xhttp.open("POST", ssoRootUri + "/api/v1/logout", true);
       xhttp.withCredentials = true
@@ -43,16 +43,16 @@
     }
 
     function init() {
+      jwt = null
       document.getElementById("ssoRootUri").innerHTML = ssoRootUri
-
+      document.getElementById("exampleRootUri").innerHTML = exampleRootUri
+      document.getElementById("greeting").innerHTML = ""
       var xhttp = new XMLHttpRequest()
-      xhttp.onreadystatechange = function() {
-        if (this.readyState == 4) {
-          if (xhttp.status == 403) {
-            document.getElementById("whoami").innerHTML = "Not logged in."
-          } else {
-            setJwt(xhttp.responseText)
-          }
+      xhttp.onload = function() {
+        if (xhttp.status == 403) {
+          document.getElementById("jwtContent").innerHTML = "Not logged in."
+        } else {
+          setJwt(xhttp.responseText)
         }
       }
       xhttp.open("POST", ssoRootUri + "/api/v1/refresh-token", true);
@@ -62,9 +62,25 @@
 
     function setJwt(newJwt) {
       jwt = newJwt
-      var parsed    = parseJwt(jwt) // an object
+      var parsed = parseJwt(jwt) // an object
       var formatted = JSON.stringify(parsed, null, 4)
-      document.getElementById("whoami").innerHTML = formatted
+      document.getElementById("jwtContent").innerHTML = formatted
+    }
+
+    function greet() {
+      document.getElementById("greeting").innerHTML = ""
+      var xhttp = new XMLHttpRequest()
+      xhttp.onload = function() {
+        if (xhttp.status == 403) {
+            document.getElementById("greeting").innerHTML = "Forbidden!"
+        } else {
+          document.getElementById("greeting").innerHTML = xhttp.responseText
+        }
+      }
+      xhttp.open("GET", exampleRootUri + "/echo/Hello ", true);
+      if (jwt) xhttp.setRequestHeader("Authorization", "Bearer " + jwt)
+      xhttp.withCredentials = true
+      xhttp.send(null);
     }
 
   </script>
@@ -88,20 +104,31 @@
 
     <h1>LUCUMA-SSO PLAYGROUND</h1>
 
-    <div>
-      This page is hitting the SSO server at <span style="font-weight: bold;" id="ssoRootUri"></span>.
-    </div>
+    <h3>Configuration</h3>
+    Edit the page source to change these.
+    <ul>
+      <li>The SSO server is at <span style="font-weight: bold;" id="ssoRootUri"></span>.</li>
+      <li>The example service is at <span style="font-weight: bold;" id="exampleRootUri"></span>.</li>
+    </ul>
 
-    <div>
-      <div id="whoami" class="preformatted">
-      </div>
-    </div>
-
+    <h3>Possibilities</h3>
     <ul>
       <li><a href="javascript:authAsGuest()">Log in as guest.</a></li>
       <li><a href="javascript:authOrcid()">Log in with ORCID.</a></li>
       <li><a href="javascript:logout()">Log out.</a></li>
+      <li><a href="javascript:greet()">Attempt a greeting via an authenticated service.</a></li>
     </li>
+
+    <div>
+      <h3>JWT Content</h3>
+      <div id="jwtContent" class="preformatted"></div>
+    </div>
+
+    <div>
+      <h3>Greeting</h3>
+      <div id="greeting" class="preformatted"></div>
+    </div>
+
 
   </body>
 </html>


### PR DESCRIPTION
This adds an example back-end service that receives the `Authorization: Bearer <jwt>` header and extracts the user (or rejects the request) and extends the playground app to use demonstrate using it.