### PR TITLE
api keys

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -1,1 +1,2 @@
-web: ./modules/service/target/universal/stage/bin/main
+web: ./modules/service/target/universal/stage/bin/main serve
+create-service-user: ./modules/service/target/universal/stage/bin/main create-service-user

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,67 @@
+
+
+# Lucuma Security Overview
+
+The design goal is distributed trust/verification via token-passing, which lets us service most requests on behalf of users without having to consult a central authority.
+
+## JWTs
+
+SSO issues JSON Web Tokens (JWTs), which are cryptographically signed tokens that contain (among other things) an expiration date and user identity.
+
+API servers require that requests include a valid JWT in an `Authorization: Bearer` header. If the JWT is malformed, expired, or fails signature verification the request is rejected; otherwise the request is serviced under the encoded identity.
+
+Lucuma JWTs expire after ten minutes and must be renewed (see **JWT Refresh** below).
+
+#### Discussion
+
+The Lucuma JWT is visible to Javascript code and is in principle vulnerable to theft via scripting attack. The short lifetime mitigates this threat somewhat.
+
+## JWT Refresh
+
+SSO issues a non-expiring HTTP-Only cookie representing the user's persistent session. This cookie allows retrieval of a (new) JWT from SSO at any time. By this mechanism web applications can resume user sessions on load, and can replace JWTs before they expire.
+
+When a user logs out, the session is deleted from SSO and the (now invalid) cookie is forgotten.
+
+#### Discussion
+
+HTTP Only cookies are not accessible from Javascript and are only sent with secure requests, so they can only be stolen by a thief who has physical access to a user's machine.
+
+## API Keys
+
+> not implemented yet
+
+Advanced users can request an API key, which functions much like a JWT but does not expire and must be revoked explicitly. It is otherwise equivalent from the user's point of view and is passed in the same `Authorization: Bearer` header.
+
+API servers validate API keys with SSO, receiving user identities in response. These results are cached locally for 3h.
+
+Users can revoke API keys at any time. Cached sessions on API servers will remain active until they expire.
+
+#### Discussion
+
+SSO maintains a table of API key identifiers and hashes. The full API key is unrecoverable.
+
+Users accept responsibility for protecting API keys.
+
+## Service Accounts
+
+> not implemented yet
+
+Services which need to communicate directly (outside forwarded requests on behalf of a user) use service accounts that are created via a one-off program that is unavailable through any web API and must be invoked via `heroku run`. This program responds with a non-expiring JWT that can be provided to the API service on startup.
+
+#### Discussion
+
+Service JWTs are all-powerful, and like the SSO private key they exist only in service configuration.
+
+## SSO Signing Keys
+
+All API services are given the SSO private key as part of their configuration. If this key changes they all need to be reconfigured and restarted.
+
+#### Discussion
+
+The SSO private key is known only to SSO, and exists only as part of the service configuration on Heroku. Theft would require access to the organization's Heroku account.
+
+A DNS attack could allow someone to spoof SSO, but without the private key no API server would accept JWTs it issued. This is why API servers do not ask SSO for its key on startup, and instead have it hardcoded into their configuration.
+
+## ORCID Authentication
+
+SSO delegates authentication to ORCID via an OAuth2 token exchange. User profile information is updated in the SSO cache on login and will propagate to use JWTs and API key sessions as they expire.

--- a/build.sbt
+++ b/build.sbt
@@ -64,7 +64,9 @@ lazy val service = project
       "org.tpolecat"   %% "skunk-core"          % "0.0.21",
       "org.flywaydb"   % "flyway-core"          % "6.5.7",
       "org.postgresql" % "postgresql"           % "42.2.18",
-    ),
+      "com.monovore"   %% "decline-effect"      % "1.3.0",
+      "com.monovore"   %% "decline"             % "1.3.0",
+    )
   )
 
 lazy val backendExample = project

--- a/build.sbt
+++ b/build.sbt
@@ -41,6 +41,7 @@ lazy val backendClient = project
       "org.http4s"        %% "http4s-circe"   % "0.21.8",
       "org.http4s"        %% "http4s-circe"   % "0.21.8",
       "org.http4s"        %% "http4s-dsl"     % "0.21.8",
+      "org.http4s"        %% "http4s-client"  % "0.21.8",
       "io.chrisdavenport" %% "log4cats-slf4j" % "1.1.1",
     ),
   )

--- a/modules/backend-client/src/main/scala/SsoClient.scala
+++ b/modules/backend-client/src/main/scala/SsoClient.scala
@@ -1,0 +1,170 @@
+// Copyright (c) 2016-2020 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package lucuma.sso.client
+
+import cats.data.OptionT
+import cats.effect.concurrent.Ref
+import cats.effect.Sync
+import cats.Monad
+import cats.syntax.all._
+import java.time.Instant
+import lucuma.core.model.User
+import org.http4s._
+import org.http4s.client.Client
+import org.http4s.dsl.Http4sDsl
+import org.http4s.headers.Authorization
+import org.http4s.util.CaseInsensitiveString
+import scala.collection.immutable.TreeMap
+import scala.concurrent.duration._
+
+/** An SSO client that extracts user information of type `A` from API keys and JWTs. */
+trait SsoClient[F[_], A] {
+
+  /** Find authorization information in the specified request, if present and valid. */
+  def find(req: Request[F]): F[Option[A]]
+
+  /**
+   * Find authorization information and pass it to the specified response handler, responding with
+   * `403 Forbidden` if the information is not present. This is a common use case for `find` and is
+   * provided as a convenience.
+   */
+  def require(req: Request[F])(f: A => F[Response[F]]): F[Response[F]]
+
+  /** Transform the result of `find` using the specified function. */
+  def map[B](f: A => B): SsoClient[F, B]
+
+  /** Filter the result of `find` using the specified function. */
+  def filter(f: A => Boolean): SsoClient[F, A]
+
+  /**
+   * Filter and transform the result of `find` using the specified partial function.
+   * {{{
+   *
+   * // Standard initial client.
+   * val client: SsoClient[F, UserInfo] = ...
+   *
+   * // Client that only sees `StandardUser`.
+   * val std: SsoClient[F, StandardUser] =
+   *   client.collect {
+   *     case UserInfo(s: StandardUser, _, _) => s
+   *   }
+   *
+   * ...
+   *
+   * // Match but respond with 403 Forbidden unless there's a `StandardUser`
+   * case GET -> Root / "something" / "restricted" =>
+   *   std.require(req) { su =>
+   *     val role = su.role
+   *     ...
+   *   }
+   * }}}
+   */
+  def collect[B](f: PartialFunction[A, B]): SsoClient[F, B]
+
+}
+
+
+object SsoClient {
+
+  /**
+   * Complete set of user information, as retrieved from an HTTP request.
+   * @param user   the user, extracted from JWT
+   * @param claim  the entire JWT claim
+   * @param header HTTP `Authorization: Bearer <jwt>` header containing the encoded JWT, which can
+   *   be included in further requests made on behalf of the user.
+   */
+  case class UserInfo(user: User, claim: SsoJwtClaim, header: Authorization) {
+    assert(claim.getUser == Right(user)) // sanity check
+  }
+
+  /**
+   * Construct an initial SSO client that extracts `UserInfo` from `Authorization: Bearer` headers,
+   * exchanging and caching API keys as required. Transformations of this client share the same
+   * underlyiny API key cache. Note that the cache is never expunged; we rely on server cycling.
+   */
+  def initial[F[_]: Sync](
+    httpClient:  Client[F],
+    ssoRoot:     Uri,
+    jwtReader:   SsoJwtReader[F],
+    gracePeriod: FiniteDuration = 5.minutes,
+    serviceJwt:  String,
+  ): F[SsoClient[F, UserInfo]] =
+    Ref[F].of(TreeMap.empty[ApiKey, UserInfo]).map { ref =>
+
+      val Bearer = CaseInsensitiveString("Bearer")
+
+      def authorization(jwt: String): Authorization =
+        Authorization(Credentials.Token(Bearer, jwt))
+
+      def getCachedApiInfo(apiKey: ApiKey): F[Option[UserInfo]] =
+        Sync[F].delay(Instant.now().plusSeconds(gracePeriod.toSeconds)).flatMap { t =>
+          ref.get.map(_.get(apiKey).filter(_.claim.expiration.isAfter(t)))
+        }
+
+      def exchangeRequest(apiKey: ApiKey): Request[F] =
+        Request(
+          method  = Method.GET,
+          uri     = (ssoRoot / "api" / "v1" / "exchange-api-key").withQueryParam("key", apiKey),
+          headers = Headers.of(authorization(serviceJwt))
+        )
+
+      def fetchApiInfo(apiKey: ApiKey): F[UserInfo] =
+        for {
+          jwt   <- httpClient.expect[String](exchangeRequest(apiKey))
+          claim <- jwtReader.decodeClaim(jwt)
+          user  <- claim.getUser.liftTo[F] // this really is a server error
+          info   = UserInfo(user, claim, authorization(jwt))
+          _     <- ref.update(m => m + (apiKey -> info))
+        } yield info
+
+      def getApiInfo(apiKey: ApiKey): F[UserInfo] =
+        OptionT(getCachedApiInfo(apiKey)).getOrElseF(fetchApiInfo(apiKey))
+
+      def findBearerAuthorization(req: Request[F]): F[Option[String]]  =
+        req.headers.collectFirst {
+          case Authorization(Authorization(Credentials.Token(Bearer, token))) => token
+        } .pure[F]
+
+      def findApiKey(req: Request[F]): F[Option[ApiKey]] =
+        findBearerAuthorization(req).map(_.flatMap(ApiKey.fromString.getOption))
+
+      def findApiInfo(req: Request[F]): F[Option[UserInfo]] =
+        OptionT(findApiKey(req)).semiflatMap(getApiInfo).value
+
+      def findJwtInfo(req: Request[F]): F[Option[UserInfo]] =
+        OptionT(findBearerAuthorization(req)).semiflatMap { jwt =>
+          for {
+            claim <- jwtReader.decodeClaim(jwt)
+            user  <- claim.getUser.liftTo[F]
+            info   = UserInfo(user, claim, authorization(jwt))
+          } yield info
+        } .value
+
+      new AbstractSsoClient2[F, UserInfo] {
+        def find(req: Request[F]): F[Option[UserInfo]] =
+          (OptionT(findApiInfo(req)) <+> OptionT(findJwtInfo(req))).value
+      }
+
+    }
+
+  private abstract class AbstractSsoClient2[F[_]: Monad, A] extends SsoClient[F, A] { outer =>
+
+    object FDsl extends Http4sDsl[F]
+    import FDsl._
+
+    final def require(req: Request[F])(f: A => F[Response[F]]): F[Response[F]] =
+      OptionT(find(req)).cataF(Forbidden(), f)
+
+    private def transform[B](f: Option[A] => Option[B]): SsoClient[F, B] =
+      new AbstractSsoClient2[F, B] {
+        def find(req: Request[F]) = outer.find(req).map(f)
+      }
+
+    final def map[B](f: A => B): SsoClient[F, B] = transform(_ map f)
+    final def filter(f: A => Boolean): SsoClient[F, A] = transform(_ filter f)
+    final def collect[B](f: PartialFunction[A, B]): SsoClient[F, B] = transform(_ collect f)
+
+  }
+
+}

--- a/modules/backend-client/src/main/scala/SsoJwtClaim.scala
+++ b/modules/backend-client/src/main/scala/SsoJwtClaim.scala
@@ -7,6 +7,7 @@ import pdi.jwt.JwtClaim
 import lucuma.core.model.User
 import lucuma.sso.client.codec.user._
 import io.circe.parser.parse
+import java.time.Instant
 
 final case class SsoJwtClaim(jwtClaim: JwtClaim) {
   import SsoJwtClaim._
@@ -16,6 +17,9 @@ final case class SsoJwtClaim(jwtClaim: JwtClaim) {
       json  <- parse(jwtClaim.content)
       user  <- json.hcursor.downField(lucumaUser).as[User]
     } yield user
+
+  def expiration: Instant =
+    jwtClaim.expiration.fold(Instant.MAX)(Instant.ofEpochSecond)
 
 }
 

--- a/modules/service/src/main/resources/db/migration/V003__Api_Key.sql
+++ b/modules/service/src/main/resources/db/migration/V003__Api_Key.sql
@@ -1,0 +1,29 @@
+CREATE DOMAIN lucuma_api_key_id AS VARCHAR;
+
+CREATE SEQUENCE lucuma_api_key_sequence START WITH 256;
+CREATE TABLE lucuma_api_key (
+
+  api_key_id     lucuma_api_key_id NOT NULL PRIMARY KEY,
+  user_id        lucuma_user_id    NOT NULL,
+  role_id        lucuma_role_id    NOT NULL,
+  api_key_hash   CHAR(32)          NOT NULL,
+
+  -- user+role must exist in lucuma_role
+  FOREIGN KEY (user_id, role_id)
+  REFERENCES lucuma_role (user_id, role_id)
+  ON UPDATE CASCADE
+  ON DELETE CASCADE
+
+);
+
+CREATE OR REPLACE FUNCTION insert_api_key(user_id lucuma_user_id, role_id lucuma_role_id) RETURNS text AS $$
+  DECLARE
+    api_key_id lucuma_api_key_id := to_hex(nextval('lucuma_api_key_sequence'::regclass));
+    api_key text := md5(random()::text) || md5(random()::text) ||  md5(random()::text);
+    api_key_hash text := md5(api_key);
+  BEGIN
+    INSERT INTO lucuma_api_key (api_key_id, user_id, role_id, api_key_hash)
+    VALUES (api_key_id, user_id, role_id, api_key_hash);
+    RETURN api_key_id || '.' || api_key;
+  END;
+$$ LANGUAGE plpgsql;

--- a/modules/service/src/main/scala/ApiKey.scala
+++ b/modules/service/src/main/scala/ApiKey.scala
@@ -1,0 +1,55 @@
+// Copyright (c) 2016-2020 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package lucuma.sso.service
+
+import cats.effect.Sync
+import cats.Eq
+import cats.implicits._
+import eu.timepit.refined._
+import eu.timepit.refined.cats._
+import eu.timepit.refined.numeric.Positive
+import eu.timepit.refined.types.numeric.PosLong
+import monocle.Prism
+import org.http4s.{ DecodeResult, EntityDecoder, EntityEncoder, MalformedMessageBodyFailure }
+import scala.util.matching.Regex
+
+/**
+ * An API key consists of an id (a positive Long) and a cleartext body (a 96-char lowecase hex
+ * string). API keys have a canonical string representation `id.body` where `id` is in lowercase
+ * hex, for example:
+ * {{{
+ * 10d.3b9e2adc5bffdac72f487a2760061bcfebc44037b69f2085c9a1ba10aa5d2d338421fc0d79f45cfd07666617ac4e2c89
+ * }}}
+ */
+final case class ApiKey(id: PosLong, body: String)
+object ApiKey {
+
+  private val R: Regex =
+    raw"^([0-9a-f]{3,})\.([0-9a-f]{96})$$".r
+
+  val fromString: Prism[String, ApiKey] =
+    Prism[String, ApiKey] {
+      case R(sid, body) =>
+        for {
+          signed <- Either.catchOnly[NumberFormatException](java.lang.Long.parseLong(sid, 16)).toOption
+          pos    <- refineV[Positive](signed).toOption
+        } yield ApiKey(pos, body)
+      case _ => None
+     } { k =>
+      s"${k.id.value.toHexString}.${k.body}"
+    }
+
+  implicit val EqSessionToken: Eq[ApiKey] =
+    Eq.by(k => (k.id, k.body))
+
+  implicit def entityEncoder[F[_]]: EntityEncoder[F, ApiKey] =
+    EntityEncoder[F, String].contramap(fromString.reverseGet)
+
+  implicit def entityDecoder[F[_]: Sync]: EntityDecoder[F, ApiKey] =
+    EntityDecoder[F, String].map(fromString.getOption).flatMapR {
+      case Some(ak) => DecodeResult.success(ak)
+      case None     => DecodeResult.failure(MalformedMessageBodyFailure("Invalid API Key"))
+    }
+
+}

--- a/modules/service/src/main/scala/ApiKey.scala
+++ b/modules/service/src/main/scala/ApiKey.scala
@@ -13,6 +13,8 @@ import eu.timepit.refined.types.numeric.PosLong
 import monocle.Prism
 import org.http4s.{ DecodeResult, EntityDecoder, EntityEncoder, MalformedMessageBodyFailure }
 import scala.util.matching.Regex
+import org.http4s.QueryParamDecoder
+import org.http4s.ParseFailure
 
 /**
  * An API key consists of an id (a positive Long) and a cleartext body (a 96-char lowecase hex
@@ -51,5 +53,10 @@ object ApiKey {
       case Some(ak) => DecodeResult.success(ak)
       case None     => DecodeResult.failure(MalformedMessageBodyFailure("Invalid API Key"))
     }
+
+  implicit val queryParamDecoder: QueryParamDecoder[ApiKey] =
+    QueryParamDecoder[String]
+      .map(fromString.getOption)
+      .emap(_.toRight(ParseFailure("<redacted>", "Invalid API Key")))
 
 }

--- a/modules/service/src/main/scala/Main.scala
+++ b/modules/service/src/main/scala/Main.scala
@@ -19,7 +19,7 @@ import org.http4s.ember.client.EmberClientBuilder
 import org.http4s.ember.server.EmberServerBuilder
 import org.http4s.implicits._
 import org.http4s.server._
-import skunk._
+import skunk.{ Command => _, _ }
 import io.chrisdavenport.log4cats.Logger
 import cats.data.Kleisli
 import io.chrisdavenport.log4cats.slf4j.Slf4jLogger
@@ -28,16 +28,50 @@ import java.io.ByteArrayOutputStream
 import java.io.OutputStreamWriter
 import java.io.PrintWriter
 import org.http4s.Uri.Scheme
+import com.monovore.decline.effect.CommandIOApp
+import com.monovore.decline._
+import lucuma.core.model.ServiceUser
+import lucuma.core.model.User
+import eu.timepit.refined.auto._
+import scala.concurrent.duration._
 
-object Main extends IOApp {
+object Main extends CommandIOApp(
+  name    = "lucuma-sso",
+  header  =
+    s"""|╦  ╦ ╦╔═╗╦ ╦╔╦╗╔═╗   ╔═╗╔═╗╔═╗
+        |║  ║ ║║  ║ ║║║║╠═╣───╚═╗╚═╗║ ║
+        |╩═╝╚═╝╚═╝╚═╝╩ ╩╩ ╩   ╚═╝╚═╝╚═╝
+        |
+        |This is the Lucuma SSO service, which also has a few utility commands that must be invoked
+        |here because they cannot appear in the public API.
+        |
+        |Configuration is entirely by environment variable or by Java system property.
+        |""".stripMargin,
+) {
 
-  /** A logger we can use everywhere. */
+  def main: Opts[IO[ExitCode]] =
+    command
+
   implicit val logger: Logger[IO] =
     Slf4jLogger.getLoggerFromName("lucuma-sso")
 
-  /** Our main program, which runs forever, and can be stopped with ^C. */
-  def run(args: List[String]): IO[ExitCode] =
-    FMain.main[IO]
+  lazy val serve =
+    Command(
+      name   = "serve",
+      header = "Run the SSO service.",
+    )(FMain.serve[IO].pure[Opts])
+
+  lazy val createServiceUser =
+    Command(
+      name   = "create-service-user",
+      header = "Create a new service user."
+    )(Opts.argument[String](metavar = "name").map(FMain.createServiceUser[IO](_)))
+
+  lazy val command =
+    Opts.subcommands(
+      serve,
+      createServiceUser
+    )
 
 }
 
@@ -158,10 +192,10 @@ object FMain {
     Logger[F].mapK(Kleisli.liftK)
 
   /**
-   * Our main program, as a resource that starts up our server on acquire and shuts it all down
+   * Our main server, as a resource that starts up our server on acquire and shuts it all down
    * in cleanup, yielding an `ExitCode`. Users will `use` this resource and hold it forever.
    */
-  def rmain[F[_]: Concurrent: ContextShift: Timer: Logger]: Resource[F, ExitCode] =
+  def server[F[_]: Concurrent: ContextShift: Timer: Logger]: Resource[F, ExitCode] =
     for {
       c  <- Resource.liftF(Config.config.load[F])
       _  <- Resource.liftF(banner[F](c))
@@ -171,9 +205,38 @@ object FMain {
       _  <- serverResource(c.httpPort, ap)
     } yield ExitCode.Success
 
-  /** Our main program, which runs forever. */
-  def main[F[_]: Concurrent: ContextShift: Timer: Logger]: F[ExitCode] =
-    rmain.use(_ => Concurrent[F].never[ExitCode])
+  /** Our main server, which runs forever. */
+  def serve[F[_]: Concurrent: ContextShift: Timer: Logger]: F[ExitCode] =
+    server.use(_ => Concurrent[F].never[ExitCode])
+
+  /** Standalone single-use database instance for one-off commands. */
+  def standaloneDatabase[F[_]: Concurrent: ContextShift: Timer: Logger](
+    config: DatabaseConfig
+  ): Resource[F, Database[F]] = {
+    import Trace.Implicits.noop
+    databasePoolResource(config).flatten.map(Database.fromSession(_))
+  }
+
+  /** A one-off command that creates a service user. */
+  def createServiceUser[F[_]: Concurrent: ContextShift: Timer: Logger](
+    name: String
+  ): F[ExitCode] =
+    Config.config.load[F].flatMap { config =>
+      standaloneDatabase(config.database).use { _ =>
+        for {
+          _    <- Sync[F].unit
+          user  = ServiceUser(User.Id(1L), name)
+          _    <- Sync[F].delay(println())
+          _    <- Sync[F].delay(println(s"⚠️  JWT for service user '${user.name}' (${user.id}) is valid for 20 years."))
+          _    <- Sync[F].delay(println(s"⚠️  Place this value in your service configuration and do not replicate it elsewhere."))
+          _    <- Sync[F].delay(println(s"⚠️  If it is lost you may re-run this command to get a new one."))
+          _    <- Sync[F].delay(println())
+          jwt  <- config.ssoJwtWriter.newJwt(user, Some((365 * 20).days)) // 20 years should be enough
+          _    <- Sync[F].delay(println(s"${Console.GREEN}$jwt${Console.RESET}"))
+          _    <- Sync[F].delay(println())
+        } yield ExitCode.Success
+      }
+    }
 
 }
 

--- a/modules/service/src/main/scala/Main.scala
+++ b/modules/service/src/main/scala/Main.scala
@@ -114,9 +114,11 @@ object FMain {
   def routesResource[F[_]: Concurrent: ContextShift: Trace: Timer: Logger](config: Config): Resource[F, HttpRoutes[F]] =
     (databasePoolResource[F](config.database), orcidServiceResource(config.orcid))
       .mapN { (pool, orcid) =>
+        val dbPool = pool.map(Database.fromSession(_))
         Routes[F](
-          dbPool    = pool.map(Database.fromSession(_)),
+          dbPool    = dbPool,
           orcid     = orcid,
+          jwtReader = config.ssoJwtReader,
           jwtWriter = config.ssoJwtWriter,
           publicUri = config.publicUri,
           cookies   = CookieService[F](config.cookieDomain, config.scheme === Scheme.https),

--- a/modules/service/src/main/scala/Routes.scala
+++ b/modules/service/src/main/scala/Routes.scala
@@ -18,6 +18,7 @@ import io.chrisdavenport.log4cats.Logger
 import scala.concurrent.duration._
 import lucuma.core.model.StandardRole
 import lucuma.core.util.Gid
+import lucuma.sso.client._
 
 object Routes {
 

--- a/modules/service/src/main/scala/config/Config.scala
+++ b/modules/service/src/main/scala/config/Config.scala
@@ -120,13 +120,3 @@ object Config {
       }
 
 }
-
-object ConfigTest extends IOApp {
-
-  def run(args: List[String]): IO[ExitCode] =
-    for {
-      cfg <- Config.config.load[IO]
-      _   <- IO(println(cfg))
-    } yield ExitCode.Success
-
-}

--- a/modules/service/src/main/scala/database/Codecs.scala
+++ b/modules/service/src/main/scala/database/Codecs.scala
@@ -10,7 +10,7 @@ import skunk.codec.all._
 import skunk.data.Type
 import lucuma.core.util.Enumerated
 import lucuma.sso.service.SessionToken
-import lucuma.sso.service.ApiKey
+import lucuma.sso.client.ApiKey
 
 // Codecs for some atomic types.
 trait Codecs {

--- a/modules/service/src/main/scala/database/Codecs.scala
+++ b/modules/service/src/main/scala/database/Codecs.scala
@@ -10,11 +10,11 @@ import skunk.codec.all._
 import skunk.data.Type
 import lucuma.core.util.Enumerated
 import lucuma.sso.service.SessionToken
+import lucuma.sso.service.ApiKey
 
 // Codecs for some atomic types.
 trait Codecs {
 
-  // TODO: change this to URI in the database schema
   val orcid_id: Codec[OrcidId] =
     Codec.simple[OrcidId](
       _.value.toString(),
@@ -48,5 +48,8 @@ trait Codecs {
 
   val session_token: Codec[SessionToken] =
     uuid.gimap
+
+  val api_key: Decoder[ApiKey] =
+    text.map(ApiKey.fromString.getOption).emap(_.toRight("Invalid API Key"))
 
 }

--- a/modules/service/src/main/scala/database/Database.scala
+++ b/modules/service/src/main/scala/database/Database.scala
@@ -15,6 +15,7 @@ import cats.data.OptionT
 import skunk.data.Completion.Delete
 import cats.effect.Sync
 import eu.timepit.refined.types.numeric.PosLong
+import lucuma.sso.client.ApiKey
 
 // Minimal operations to support the basic use cases … add more when we add the GraphQL interface
 trait Database[F[_]] {

--- a/modules/service/src/main/scala/database/Database.scala
+++ b/modules/service/src/main/scala/database/Database.scala
@@ -58,7 +58,7 @@ trait Database[F[_]] {
   // def promoteUser(id: User.Id, profile: OrcidProfile, role: RoleRequest): F[StandardUser]
 
   def createApiKey(roleId: StandardRole.Id): F[ApiKey]
-  def getStandardUserFromApiKey(apiKey: ApiKey): F[StandardUser]
+  def findStandardUserFromApiKey(apiKey: ApiKey): F[Option[StandardUser]]
   def deleteApiKey(keyId: PosLong): F[Unit]
 
 }
@@ -256,12 +256,6 @@ object Database extends Codecs {
                   (user.copy(role = activeRole, otherRoles = roles.filterNot(_.id === roleId))).some.pure[F]
               }
           }
-        }
-
-    def getStandardUserFromApiKey(apiKey: ApiKey): F[StandardUser] =
-      findStandardUserFromApiKey(apiKey).flatMap {
-          case None => Sync[F].raiseError(new RuntimeException(s"Invalid API Key"))
-          case Some(u) => u.pure[F]
         }
 
     def findStandardUserFromApiKey(

--- a/modules/service/src/test/scala/ApiKeySuite.scala
+++ b/modules/service/src/test/scala/ApiKeySuite.scala
@@ -1,0 +1,55 @@
+package lucuma.sso.service
+
+import cats.effect._
+import cats.implicits._
+import lucuma.sso.service.simulator.SsoSimulator
+import org.http4s.headers.Location
+
+object ApiKeySuite extends SsoSuite with Fixture {
+
+  simpleTest("Create and redeem an API key.") {
+    SsoSimulator[IO].use { case (db, sim, sso, _) =>
+      val stage1  = (SsoRoot / "auth" / "v1" / "stage1").withQueryParam("state", ExploreRoot)
+      for {
+
+        // Log in as Bob
+        redir  <- sso.get(stage1)(_.headers.get(Location).map(_.uri).get.pure[IO])
+        stage2 <- sim.authenticate(redir, Bob, None)
+        tok    <- sso.get(stage2)(CookieReader[IO].getSessionToken)
+        user   <- db.use(_.getStandardUserFromToken(tok))
+
+        // Create an API Key
+        apiKey <- db.use(_.createApiKey(user.role.id))
+
+        // Redeem it
+        user2  <- db.use(_.getStandardUserFromApiKey(apiKey))
+
+      } yield expect(user == user2)
+    } .onError(e => IO(println(e)))
+  }
+
+  simpleTest("Delete an API key and try to re-use it.") {
+    SsoSimulator[IO].use { case (db, sim, sso, _) =>
+      val stage1  = (SsoRoot / "auth" / "v1" / "stage1").withQueryParam("state", ExploreRoot)
+      for {
+
+        // Log in as Bob
+        redir  <- sso.get(stage1)(_.headers.get(Location).map(_.uri).get.pure[IO])
+        stage2 <- sim.authenticate(redir, Bob, None)
+        tok    <- sso.get(stage2)(CookieReader[IO].getSessionToken)
+        user   <- db.use(_.getStandardUserFromToken(tok))
+
+        // Create an API Key
+        apiKey <- db.use(_.createApiKey(user.role.id))
+
+        // Delete it
+        _      <- db.use(_.deleteApiKey(apiKey.id))
+
+        // Try to redeem it, should fail
+        ex     <- db.use(_.getStandardUserFromApiKey(apiKey)).attempt
+
+      } yield expect(ex.isLeft)
+    } .onError(e => IO(println(e)))
+  }
+
+}

--- a/modules/service/src/test/scala/CorsSuite.scala
+++ b/modules/service/src/test/scala/CorsSuite.scala
@@ -12,6 +12,7 @@ object CorsSuite extends SsoSuite {
       Routes[IO](
         dbPool    = null,
         orcid     = null,
+        jwtReader = null,
         jwtWriter = null,
         publicUri = uri"http://unused",
         cookies   = null,

--- a/modules/service/src/test/scala/ExistingUserSuite.scala
+++ b/modules/service/src/test/scala/ExistingUserSuite.scala
@@ -9,7 +9,7 @@ import org.http4s.headers.Location
 object ExistingUserSuite extends SsoSuite with Fixture {
 
   simpleTest("Log in as existing user.") {
-    SsoSimulator[IO].use { case (db, sim, sso, _) =>
+    SsoSimulator[IO].use { case (db, sim, sso, _, _) =>
       val stage1  = (SsoRoot / "auth" / "v1" / "stage1").withQueryParam("state", ExploreRoot)
       for {
 

--- a/modules/service/src/test/scala/GuestUserSuite.scala
+++ b/modules/service/src/test/scala/GuestUserSuite.scala
@@ -14,7 +14,7 @@ object GuestUserSuite extends SsoSuite with Fixture {
 
   simpleTest("Guest Login.") {
     SsoSimulator[IO]
-      .flatMap { case (pool, _, sso, jwtReader) => pool.map(db => (db, sso, jwtReader)) }
+      .flatMap { case (pool, _, sso, jwtReader, _) => pool.map(db => (db, sso, jwtReader)) }
       .use { case (db, sso, jwtReader) =>
         sso.run(
           Request(
@@ -39,7 +39,7 @@ object GuestUserSuite extends SsoSuite with Fixture {
   simpleTest("Guest user promotion.") {
     val stage1  = (SsoRoot / "auth" / "v1" / "stage1").withQueryParam("state", ExploreRoot)
     SsoSimulator[IO]
-      .flatMap { case (pool, sim, sso, jwtReader) => pool.map(db => (db, sim, sso, jwtReader)) }
+      .flatMap { case (pool, sim, sso, jwtReader, _) => pool.map(db => (db, sim, sso, jwtReader)) }
       .use { case (db, sim, sso, jwtReader) =>
 
         val loginAsGuest: IO[(User.Id, SessionToken)] =
@@ -81,7 +81,7 @@ object GuestUserSuite extends SsoSuite with Fixture {
   }
 
   simpleTest("Log in as guest, then as existing user.") {
-    SsoSimulator[IO].use { case (db, sim, sso, _) =>
+    SsoSimulator[IO].use { case (db, sim, sso, _, _) =>
       val stage1  = (SsoRoot / "auth" / "v1" / "stage1").withQueryParam("state", ExploreRoot)
       for {
 

--- a/modules/service/src/test/scala/NewUserSuite.scala
+++ b/modules/service/src/test/scala/NewUserSuite.scala
@@ -10,7 +10,7 @@ import lucuma.core.model.Access
 object NewUserSuite extends SsoSuite with Fixture {
 
   simpleTest("Bob logs in via ORCID as a new lucuma user.") {
-    SsoSimulator[IO].use { case (db, sim, sso, _) =>
+    SsoSimulator[IO].use { case (db, sim, sso, _, _) =>
       val stage1  = (SsoRoot / "auth" / "v1" / "stage1").withQueryParam("state", ExploreRoot)
       for {
 

--- a/modules/service/src/test/scala/SsoClientSuite.scala
+++ b/modules/service/src/test/scala/SsoClientSuite.scala
@@ -1,0 +1,144 @@
+package lucuma.sso.service
+
+import lucuma.sso.client.SsoClient
+import lucuma.sso.client.SsoClient.UserInfo
+import org.http4s.client.Client
+import org.http4s.HttpRoutes
+
+import cats.effect._
+import cats.syntax.all._
+import org.http4s.dsl.io._
+import org.http4s.implicits._
+import lucuma.sso.service.simulator.SsoSimulator
+import org.http4s.headers._
+import org.http4s._
+import lucuma.core.model.ServiceUser
+import lucuma.core.model.User
+import eu.timepit.refined.auto._
+import scala.concurrent.duration._
+import org.http4s.Credentials
+import org.http4s.Headers
+import org.http4s.util.CaseInsensitiveString
+import lucuma.sso.client.ApiKey
+
+object SsoClientSuite extends SsoSuite with Fixture {
+
+  def routes(ssoClient: SsoClient[IO, UserInfo]): HttpRoutes[IO] =
+    HttpRoutes.of[IO] {
+      case r@(GET -> Root / "echo-name") =>
+        ssoClient.map(_.user).require(r) { u =>
+          Ok(u.displayName)
+        }
+    }
+
+  def otherServer(ssoClient: SsoClient[IO, UserInfo]): Client[IO] =
+    Client.fromHttpApp(routes(ssoClient).orNotFound)
+
+  simpleTest("Call a remote service with a JWT.") {
+    SsoSimulator[IO].use { case (_, sim, sso, reader, writer) =>
+      val stage1  = (SsoRoot / "auth" / "v1" / "stage1").withQueryParam("state", ExploreRoot)
+      val Bearer = CaseInsensitiveString("Bearer")
+      for {
+
+        // Create our SSO Client
+        serviceJwt <- writer.newJwt(ServiceUser(User.Id(1L), "bogus")) // need to call as a service user
+        ssoClient  <- SsoClient.initial[IO](
+          httpClient = sso,
+          ssoRoot = uri"http://ignored",
+          jwtReader = reader,
+          gracePeriod = 5.minutes,
+          serviceJwt = serviceJwt
+        )
+        other = otherServer(ssoClient)
+
+        // Log in as Bob
+        redir  <- sso.get(stage1)(_.headers.get(Location).map(_.uri).get.pure[IO])
+        stage2 <- sim.authenticate(redir, Bob, None)
+        _      <- sso.get(stage2)(CookieReader[IO].getSessionToken) // cookie is set here
+        jwt    <- sso.expect[String](Request[IO](method = Method.POST, uri = SsoRoot / "api" / "v1" / "refresh-token"))
+
+        // Call the other server!
+        name   <- other.expect[String](
+                    Request[IO](
+                      uri = uri"http://whatever.com/echo-name",
+                      headers = Headers.of(Authorization(Credentials.Token(Bearer, jwt)))
+                    )
+                  )
+
+      } yield expect(name == "Bob Dobbs")
+
+    }
+  }
+
+  simpleTest("Call a remote service with an API key.") {
+    SsoSimulator[IO].use { case (db, sim, sso, reader, writer) =>
+      val stage1  = (SsoRoot / "auth" / "v1" / "stage1").withQueryParam("state", ExploreRoot)
+      val Bearer = CaseInsensitiveString("Bearer")
+      for {
+
+        // Create our SSO Client
+        serviceJwt <- writer.newJwt(ServiceUser(User.Id(1L), "bogus")) // need to call as a service user
+        ssoClient  <- SsoClient.initial[IO](
+          httpClient  = sso,
+          ssoRoot     = SsoRoot,
+          jwtReader   = reader,
+          gracePeriod = 5.minutes,
+          serviceJwt  = serviceJwt
+        )
+        other = otherServer(ssoClient)
+
+        // Log in as Bob
+        redir  <- sso.get(stage1)(_.headers.get(Location).map(_.uri).get.pure[IO])
+        stage2 <- sim.authenticate(redir, Bob, None)
+        tok    <- sso.get(stage2)(CookieReader[IO].getSessionToken) // cookie is set here
+        user   <- db.use(_.getStandardUserFromToken(tok))
+        apiKey <- db.use(_.createApiKey(user.role.id))
+
+        // Call the other server!
+        name   <- other.expect[String](
+                    Request[IO](
+                      uri = uri"http://whatever.com/echo-name",
+                      headers = Headers.of(Authorization(Credentials.Token(Bearer, ApiKey.fromString.reverseGet(apiKey))))
+                    )
+                  )
+
+      } yield expect(name == "Bob Dobbs")
+
+    }
+  }
+
+
+  simpleTest("Can't call remote service with no user.") {
+    SsoSimulator[IO].use { case (_, sim, sso, reader, writer) =>
+      val stage1  = (SsoRoot / "auth" / "v1" / "stage1").withQueryParam("state", ExploreRoot)
+      for {
+
+        // Create our SSO Client
+        serviceJwt <- writer.newJwt(ServiceUser(User.Id(1L), "bogus")) // need to call as a service user
+        ssoClient  <- SsoClient.initial[IO](
+          httpClient  = sso,
+          ssoRoot     = SsoRoot,
+          jwtReader   = reader,
+          gracePeriod = 5.minutes,
+          serviceJwt  = serviceJwt
+        )
+        other = otherServer(ssoClient)
+
+        // Log in as Bob
+        redir  <- sso.get(stage1)(_.headers.get(Location).map(_.uri).get.pure[IO])
+        stage2 <- sim.authenticate(redir, Bob, None)
+        _      <- sso.get(stage2)(CookieReader[IO].getSessionToken) // cookie is set here
+
+        // Call the other server!
+        status <- other.status(
+                    Request[IO](
+                      uri = uri"http://whatever.com/echo-name",
+                    )
+                  )
+
+      } yield expect(status == Status.Forbidden)
+
+    }
+  }
+
+}

--- a/modules/service/src/test/scala/simulator/SsoSimulator.scala
+++ b/modules/service/src/test/scala/simulator/SsoSimulator.scala
@@ -27,6 +27,7 @@ object SsoSimulator {
         (sessionPool, sim, Routes[F](
           dbPool    = sessionPool,
           orcid     = OrcidService(OrcidConfig.orcidHost(Environment.Production), "unused", "unused", sim.client),
+          jwtReader = config.ssoJwtReader,
           jwtWriter = config.ssoJwtWriter,
           publicUri = config.publicUri,
           cookies   = CookieService[F]("lucuma.xyz", false),

--- a/modules/service/src/test/scala/simulator/SsoSimulator.scala
+++ b/modules/service/src/test/scala/simulator/SsoSimulator.scala
@@ -19,7 +19,7 @@ import org.http4s.client.middleware.CookieJar
 object SsoSimulator {
 
   // The exact same routes and database used by SSO, but a fake ORCID back end
-  private def httpRoutes[F[_]: Concurrent: ContextShift: Timer: Logger]: Resource[F, (Resource[F, Database[F]], OrcidSimulator[F], HttpRoutes[F], SsoJwtReader[F])] =
+  private def httpRoutes[F[_]: Concurrent: ContextShift: Timer: Logger]: Resource[F, (Resource[F, Database[F]], OrcidSimulator[F], HttpRoutes[F], SsoJwtReader[F], SsoJwtWriter[F])] =
     Resource.liftF(OrcidSimulator[F]).flatMap { sim =>
       val config = Config.local(null) // no ORCID config since we're faking ORCID
       FMain.databasePoolResource[F](config.database).map { pool =>
@@ -32,13 +32,13 @@ object SsoSimulator {
           publicUri = config.publicUri,
           cookies   = CookieService[F]("lucuma.xyz", false),
           publicKey = config.publicKey,
-        ), config.ssoJwtReader)
+        ), config.ssoJwtReader, config.ssoJwtWriter)
     }
   }
 
   /** An Http client that hits an SSO server backed by a simulated ORCID server. */
-  def apply[F[_]: Concurrent: ContextShift: Timer: Logger]: Resource[F, (Resource[F, Database[F]], OrcidSimulator[F], Client[F], SsoJwtReader[F])] = {
-    httpRoutes[F].flatMap { case (pool, sim, routes, reader) =>
+  def apply[F[_]: Concurrent: ContextShift: Timer: Logger]: Resource[F, (Resource[F, Database[F]], OrcidSimulator[F], Client[F], SsoJwtReader[F], SsoJwtWriter[F])] = {
+    httpRoutes[F].flatMap { case (pool, sim, routes, reader, writer) =>
       val client = Client.fromHttpApp(Router("/" -> routes).orNotFound)
       val clientʹ = Client[F] { req =>
         for {
@@ -48,7 +48,7 @@ object SsoSimulator {
         } yield res
       }
       Resource.liftF(CookieJar.impl[F](clientʹ)).map { client =>
-        (pool, sim, client, reader)
+        (pool, sim, client, reader, writer)
       }
     }
   }


### PR DESCRIPTION
This adds support for API keys as well as a command-line option to create a server user and associated JWT, which is required for services that wish to exchange an API key for a JWT. The service example and documentation will be updated in a followup.