### PR TITLE
fix procfile

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -1,2 +1,2 @@
-web: ./modules/service/target/universal/stage/bin/main serve
-create-service-user: ./modules/service/target/universal/stage/bin/main create-service-user
+web: ./modules/service/target/universal/stage/bin/lucuma-sso-service serve
+create-service-user: ./modules/service/target/universal/stage/bin/lucuma-sso-service create-service-user


### PR DESCRIPTION
When I removed an unused main object it changed the way native-package names the entry point.