### PR TITLE
ch489 - cookie improvements

### DIFF
--- a/modules/service/src/test/scala/RefreshTokenSuite.scala
+++ b/modules/service/src/test/scala/RefreshTokenSuite.scala
@@ -1,0 +1,48 @@
+package lucuma.sso.service
+
+import cats.effect._
+import org.http4s._
+import lucuma.sso.service.simulator.SsoSimulator
+
+object RefreshTokenSuite extends SsoSuite with Fixture {
+
+  simpleTest("Cookie shouldn't expire.") {
+    SsoSimulator[IO].use { case (_, _, sso, _, _) =>
+      for {
+        c  <- sso.run(Request(Method.POST, SsoRoot / "api" / "v1" / "auth-as-guest")).use(CookieReader[IO].getCookie(_))
+      } yield expect(c.expires == Some(HttpDate.MaxValue))
+    }
+  }
+
+  simpleTest("SomeSite should be Strict (simulator is pretending it's using https)") {
+    SsoSimulator[IO].use { case (_, _, sso, _, _) =>
+      for {
+        c  <- sso.run(Request(Method.POST, SsoRoot / "api" / "v1" / "auth-as-guest")).use(CookieReader[IO].getCookie(_))
+      } yield expect(c.sameSite == SameSite.Strict)
+    }
+  }
+
+  simpleTest("Cookie should be removed on logout.") {
+    SsoSimulator[IO].use { case (_, _, sso, _, _) =>
+      for {
+        _  <- sso.status(Request[IO](Method.POST, SsoRoot / "api" / "v1" / "auth-as-guest"))
+        c  <- sso.run(Request(Method.POST, SsoRoot / "api" / "v1" / "logout")).use(CookieReader[IO].getCookie(_))
+      } yield expect(c.expires == Some(HttpDate.Epoch))
+    }
+  }
+
+  simpleTest("Refresh should fail after logout.") {
+    SsoSimulator[IO].use { case (_, _, sso, _, _) =>
+      for {
+        _  <- sso.status(Request[IO](Method.POST, SsoRoot / "api" / "v1" / "auth-as-guest"))
+        _  <- sso.status(Request[IO](Method.POST, SsoRoot / "api" / "v1" / "logout"))
+        s  <- sso.status(Request[IO](Method.POST, SsoRoot / "api" / "v1" / "refresh-token"))
+      } yield expect(s == Status.Forbidden)
+    }
+  }
+
+}
+
+
+
+

--- a/modules/service/src/test/scala/simulator/SsoSimulator.scala
+++ b/modules/service/src/test/scala/simulator/SsoSimulator.scala
@@ -15,13 +15,14 @@ import io.chrisdavenport.log4cats.Logger
 import lucuma.sso.service.config.OrcidConfig
 import lucuma.sso.service.config.Environment
 import org.http4s.client.middleware.CookieJar
+import org.http4s.Uri
 
 object SsoSimulator {
 
   // The exact same routes and database used by SSO, but a fake ORCID back end
   private def httpRoutes[F[_]: Concurrent: ContextShift: Timer: Logger]: Resource[F, (Resource[F, Database[F]], OrcidSimulator[F], HttpRoutes[F], SsoJwtReader[F], SsoJwtWriter[F])] =
     Resource.liftF(OrcidSimulator[F]).flatMap { sim =>
-      val config = Config.local(null) // no ORCID config since we're faking ORCID
+      val config = Config.local(null).copy(scheme = Uri.Scheme.https) // no ORCID config since we're faking ORCID
       FMain.databasePoolResource[F](config.database).map { pool =>
         val sessionPool = pool.map(Database.fromSession(_))
         (sessionPool, sim, Routes[F](
@@ -30,7 +31,7 @@ object SsoSimulator {
           jwtReader = config.ssoJwtReader,
           jwtWriter = config.ssoJwtWriter,
           publicUri = config.publicUri,
-          cookies   = CookieService[F]("lucuma.xyz", false),
+          cookies   = CookieService[F]("lucuma.xyz", true),
         ), config.ssoJwtReader, config.ssoJwtWriter)
     }
   }

--- a/playground/playground.html
+++ b/playground/playground.html
@@ -5,7 +5,7 @@
   <title>LUCUMA-SSO LOCAL PLAYGROUND</title>
   <script>
 
-    var ssoRootUri     = "https://sso.gpp.lucuma.xyz"
+    var ssoRootUri     = "http://local.lucuma.xyz:8080" // "https://sso.gpp.lucuma.xyz"
     var exampleRootUri = "http://local.lucuma.xyz:8082"
 
     var jwt = null
@@ -139,6 +139,7 @@
 
     <h3>Possibilities</h3>
     <ul>
+      <li><a href="javascript:init()">Refresh token.</a></li>
       <li><a href="javascript:authAsGuest()">Log in as guest.</a></li>
       <li><a href="javascript:authOrcid()">Log in with ORCID.</a></li>
       <li><a href="javascript:createApiKey()">Create an API key (must be logged in as a real user).</a></li>


### PR DESCRIPTION
This switches `SameSite` to `Strict` when running securely (will need to test once it's in staging) and adds an explicit expiration (in the distant future) so sessions survive browser restart.