### PR TITLE
SSO GraphQL endpoint [ch739]

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -72,6 +72,8 @@ lazy val service = project
       "org.postgresql" %  "postgresql"          % "42.2.19",
       "com.monovore"   %% "decline-effect"      % "1.3.0",
       "com.monovore"   %% "decline"             % "1.3.0",
+      "edu.gemini"     %% "gsp-graphql-skunk"   % "0.0.43",
+      "io.circe"       %% "circe-literal"       % "0.13.0" % "test",
     )
   )
 

--- a/modules/backend-client/src/main/scala/SsoClient.scala
+++ b/modules/backend-client/src/main/scala/SsoClient.scala
@@ -142,7 +142,7 @@ object SsoClient {
       def getUserInfo(bearerAuthorization: String): F[Option[UserInfo]] =
         (OptionT(getApiInfo(bearerAuthorization)) <+> OptionT(getJwtInfo(bearerAuthorization))).value
 
-      new AbstractSsoClient2[F, UserInfo] {
+      new AbstractSsoClient[F, UserInfo] {
 
         def get(authorization: Authorization): F[Option[UserInfo]] =
           authorization.credentials match {
@@ -160,7 +160,7 @@ object SsoClient {
 
     }
 
-  private abstract class AbstractSsoClient2[F[_]: Monad, A] extends SsoClient[F, A] { outer =>
+  abstract class AbstractSsoClient[F[_]: Monad, A] extends SsoClient[F, A] { outer =>
 
     object FDsl extends Http4sDsl[F]
     import FDsl._
@@ -169,7 +169,7 @@ object SsoClient {
       OptionT(find(req)).cataF(Forbidden(), f)
 
     private def transform[B](f: Option[A] => Option[B]): SsoClient[F, B] =
-      new AbstractSsoClient2[F, B] {
+      new AbstractSsoClient[F, B] {
         def find(req: Request[F]) = outer.find(req).map(f)
         def get(authorization: Authorization) = outer.get(authorization).map(f)
       }

--- a/modules/service/src/main/resources/Sso.graphql
+++ b/modules/service/src/main/resources/Sso.graphql
@@ -1,0 +1,39 @@
+
+
+## Schema for standard user with minimal (PI) access.
+
+type Query {
+  user: User!
+  role: Role!
+}
+
+type User {
+  id:           UserId!
+  orcidId:      OrcidId!
+  givenName:    String
+  familyName:   String,
+  creditName:   String,
+  email:        String,
+  roles:        [Role!]!
+  apiKeys:      [ApiKey!]!
+}
+
+type Role {
+  id:      RoleId!
+  type:    RoleType!
+  partner: Partner
+  user:    User!
+}
+
+type ApiKey {
+  id:   Int!
+  user: User!
+  role: Role!
+}
+
+scalar UserId
+scalar OrcidId
+scalar RoleId
+
+enum RoleType { PI NGO STAFF ADMIN }
+enum Partner { AR BR CA CL KR UH US }

--- a/modules/service/src/main/resources/assets/playground.html
+++ b/modules/service/src/main/resources/assets/playground.html
@@ -1,0 +1,541 @@
+<!DOCTYPE html>
+
+<html>
+
+<head>
+  <meta charset=utf-8 />
+  <meta name="viewport" content="user-scalable=no, initial-scale=1.0, minimum-scale=1.0, maximum-scale=1.0, minimal-ui">
+  <title>GraphQL Playground</title>
+  <link rel="stylesheet" href="//cdn.jsdelivr.net/npm/graphql-playground-react/build/static/css/index.css" />
+  <link rel="shortcut icon" href="//cdn.jsdelivr.net/npm/graphql-playground-react/build/favicon.png" />
+  <script src="//cdn.jsdelivr.net/npm/graphql-playground-react/build/static/js/middleware.js"></script>
+
+</head>
+
+<body>
+  <style type="text/css">
+    html {
+      font-family: "Open Sans", sans-serif;
+      overflow: hidden;
+    }
+
+    body {
+      margin: 0;
+      background: #172a3a;
+    }
+
+    .playgroundIn {
+      -webkit-animation: playgroundIn 0.5s ease-out forwards;
+      animation: playgroundIn 0.5s ease-out forwards;
+    }
+
+    @-webkit-keyframes playgroundIn {
+      from {
+        opacity: 0;
+        -webkit-transform: translateY(10px);
+        -ms-transform: translateY(10px);
+        transform: translateY(10px);
+      }
+      to {
+        opacity: 1;
+        -webkit-transform: translateY(0);
+        -ms-transform: translateY(0);
+        transform: translateY(0);
+      }
+    }
+
+    @keyframes playgroundIn {
+      from {
+        opacity: 0;
+        -webkit-transform: translateY(10px);
+        -ms-transform: translateY(10px);
+        transform: translateY(10px);
+      }
+      to {
+        opacity: 1;
+        -webkit-transform: translateY(0);
+        -ms-transform: translateY(0);
+        transform: translateY(0);
+      }
+    }
+  </style>
+
+  <style type="text/css">
+    .fadeOut {
+      -webkit-animation: fadeOut 0.5s ease-out forwards;
+      animation: fadeOut 0.5s ease-out forwards;
+    }
+
+    @-webkit-keyframes fadeIn {
+      from {
+        opacity: 0;
+        -webkit-transform: translateY(-10px);
+        -ms-transform: translateY(-10px);
+        transform: translateY(-10px);
+      }
+      to {
+        opacity: 1;
+        -webkit-transform: translateY(0);
+        -ms-transform: translateY(0);
+        transform: translateY(0);
+      }
+    }
+
+    @keyframes fadeIn {
+      from {
+        opacity: 0;
+        -webkit-transform: translateY(-10px);
+        -ms-transform: translateY(-10px);
+        transform: translateY(-10px);
+      }
+      to {
+        opacity: 1;
+        -webkit-transform: translateY(0);
+        -ms-transform: translateY(0);
+        transform: translateY(0);
+      }
+    }
+
+    @-webkit-keyframes fadeOut {
+      from {
+        opacity: 1;
+        -webkit-transform: translateY(0);
+        -ms-transform: translateY(0);
+        transform: translateY(0);
+      }
+      to {
+        opacity: 0;
+        -webkit-transform: translateY(-10px);
+        -ms-transform: translateY(-10px);
+        transform: translateY(-10px);
+      }
+    }
+
+    @keyframes fadeOut {
+      from {
+        opacity: 1;
+        -webkit-transform: translateY(0);
+        -ms-transform: translateY(0);
+        transform: translateY(0);
+      }
+      to {
+        opacity: 0;
+        -webkit-transform: translateY(-10px);
+        -ms-transform: translateY(-10px);
+        transform: translateY(-10px);
+      }
+    }
+
+    @-webkit-keyframes appearIn {
+      from {
+        opacity: 0;
+        -webkit-transform: translateY(0px);
+        -ms-transform: translateY(0px);
+        transform: translateY(0px);
+      }
+      to {
+        opacity: 1;
+        -webkit-transform: translateY(0);
+        -ms-transform: translateY(0);
+        transform: translateY(0);
+      }
+    }
+
+    @keyframes appearIn {
+      from {
+        opacity: 0;
+        -webkit-transform: translateY(0px);
+        -ms-transform: translateY(0px);
+        transform: translateY(0px);
+      }
+      to {
+        opacity: 1;
+        -webkit-transform: translateY(0);
+        -ms-transform: translateY(0);
+        transform: translateY(0);
+      }
+    }
+
+    @-webkit-keyframes scaleIn {
+      from {
+        -webkit-transform: scale(0);
+        -ms-transform: scale(0);
+        transform: scale(0);
+      }
+      to {
+        -webkit-transform: scale(1);
+        -ms-transform: scale(1);
+        transform: scale(1);
+      }
+    }
+
+    @keyframes scaleIn {
+      from {
+        -webkit-transform: scale(0);
+        -ms-transform: scale(0);
+        transform: scale(0);
+      }
+      to {
+        -webkit-transform: scale(1);
+        -ms-transform: scale(1);
+        transform: scale(1);
+      }
+    }
+
+    @-webkit-keyframes innerDrawIn {
+      0% {
+        stroke-dashoffset: 70;
+      }
+      50% {
+        stroke-dashoffset: 140;
+      }
+      100% {
+        stroke-dashoffset: 210;
+      }
+    }
+
+    @keyframes innerDrawIn {
+      0% {
+        stroke-dashoffset: 70;
+      }
+      50% {
+        stroke-dashoffset: 140;
+      }
+      100% {
+        stroke-dashoffset: 210;
+      }
+    }
+
+    @-webkit-keyframes outerDrawIn {
+      0% {
+        stroke-dashoffset: 76;
+      }
+      100% {
+        stroke-dashoffset: 152;
+      }
+    }
+
+    @keyframes outerDrawIn {
+      0% {
+        stroke-dashoffset: 76;
+      }
+      100% {
+        stroke-dashoffset: 152;
+      }
+    }
+
+    .hHWjkv {
+      -webkit-transform-origin: 0px 0px;
+      -ms-transform-origin: 0px 0px;
+      transform-origin: 0px 0px;
+      -webkit-transform: scale(0);
+      -ms-transform: scale(0);
+      transform: scale(0);
+      -webkit-animation: scaleIn 0.25s linear forwards 0.2222222222222222s;
+      animation: scaleIn 0.25s linear forwards 0.2222222222222222s;
+    }
+
+    .gCDOzd {
+      -webkit-transform-origin: 0px 0px;
+      -ms-transform-origin: 0px 0px;
+      transform-origin: 0px 0px;
+      -webkit-transform: scale(0);
+      -ms-transform: scale(0);
+      transform: scale(0);
+      -webkit-animation: scaleIn 0.25s linear forwards 0.4222222222222222s;
+      animation: scaleIn 0.25s linear forwards 0.4222222222222222s;
+    }
+
+    .hmCcxi {
+      -webkit-transform-origin: 0px 0px;
+      -ms-transform-origin: 0px 0px;
+      transform-origin: 0px 0px;
+      -webkit-transform: scale(0);
+      -ms-transform: scale(0);
+      transform: scale(0);
+      -webkit-animation: scaleIn 0.25s linear forwards 0.6222222222222222s;
+      animation: scaleIn 0.25s linear forwards 0.6222222222222222s;
+    }
+
+    .eHamQi {
+      -webkit-transform-origin: 0px 0px;
+      -ms-transform-origin: 0px 0px;
+      transform-origin: 0px 0px;
+      -webkit-transform: scale(0);
+      -ms-transform: scale(0);
+      transform: scale(0);
+      -webkit-animation: scaleIn 0.25s linear forwards 0.8222222222222223s;
+      animation: scaleIn 0.25s linear forwards 0.8222222222222223s;
+    }
+
+    .byhgGu {
+      -webkit-transform-origin: 0px 0px;
+      -ms-transform-origin: 0px 0px;
+      transform-origin: 0px 0px;
+      -webkit-transform: scale(0);
+      -ms-transform: scale(0);
+      transform: scale(0);
+      -webkit-animation: scaleIn 0.25s linear forwards 1.0222222222222221s;
+      animation: scaleIn 0.25s linear forwards 1.0222222222222221s;
+    }
+
+    .llAKP {
+      -webkit-transform-origin: 0px 0px;
+      -ms-transform-origin: 0px 0px;
+      transform-origin: 0px 0px;
+      -webkit-transform: scale(0);
+      -ms-transform: scale(0);
+      transform: scale(0);
+      -webkit-animation: scaleIn 0.25s linear forwards 1.2222222222222223s;
+      animation: scaleIn 0.25s linear forwards 1.2222222222222223s;
+    }
+
+    .bglIGM {
+      -webkit-transform-origin: 64px 28px;
+      -ms-transform-origin: 64px 28px;
+      transform-origin: 64px 28px;
+      -webkit-transform: scale(0);
+      -ms-transform: scale(0);
+      transform: scale(0);
+      -webkit-animation: scaleIn 0.25s linear forwards 0.2222222222222222s;
+      animation: scaleIn 0.25s linear forwards 0.2222222222222222s;
+    }
+
+    .ksxRII {
+      -webkit-transform-origin: 95.98500061035156px 46.510000228881836px;
+      -ms-transform-origin: 95.98500061035156px 46.510000228881836px;
+      transform-origin: 95.98500061035156px 46.510000228881836px;
+      -webkit-transform: scale(0);
+      -ms-transform: scale(0);
+      transform: scale(0);
+      -webkit-animation: scaleIn 0.25s linear forwards 0.4222222222222222s;
+      animation: scaleIn 0.25s linear forwards 0.4222222222222222s;
+    }
+
+    .cWrBmb {
+      -webkit-transform-origin: 95.97162628173828px 83.4900016784668px;
+      -ms-transform-origin: 95.97162628173828px 83.4900016784668px;
+      transform-origin: 95.97162628173828px 83.4900016784668px;
+      -webkit-transform: scale(0);
+      -ms-transform: scale(0);
+      transform: scale(0);
+      -webkit-animation: scaleIn 0.25s linear forwards 0.6222222222222222s;
+      animation: scaleIn 0.25s linear forwards 0.6222222222222222s;
+    }
+
+    .Wnusb {
+      -webkit-transform-origin: 64px 101.97999572753906px;
+      -ms-transform-origin: 64px 101.97999572753906px;
+      transform-origin: 64px 101.97999572753906px;
+      -webkit-transform: scale(0);
+      -ms-transform: scale(0);
+      transform: scale(0);
+      -webkit-animation: scaleIn 0.25s linear forwards 0.8222222222222223s;
+      animation: scaleIn 0.25s linear forwards 0.8222222222222223s;
+    }
+
+    .bfPqf {
+      -webkit-transform-origin: 32.03982162475586px 83.4900016784668px;
+      -ms-transform-origin: 32.03982162475586px 83.4900016784668px;
+      transform-origin: 32.03982162475586px 83.4900016784668px;
+      -webkit-transform: scale(0);
+      -ms-transform: scale(0);
+      transform: scale(0);
+      -webkit-animation: scaleIn 0.25s linear forwards 1.0222222222222221s;
+      animation: scaleIn 0.25s linear forwards 1.0222222222222221s;
+    }
+
+    .edRCTN {
+      -webkit-transform-origin: 32.033552169799805px 46.510000228881836px;
+      -ms-transform-origin: 32.033552169799805px 46.510000228881836px;
+      transform-origin: 32.033552169799805px 46.510000228881836px;
+      -webkit-transform: scale(0);
+      -ms-transform: scale(0);
+      transform: scale(0);
+      -webkit-animation: scaleIn 0.25s linear forwards 1.2222222222222223s;
+      animation: scaleIn 0.25s linear forwards 1.2222222222222223s;
+    }
+
+    .iEGVWn {
+      opacity: 0;
+      stroke-dasharray: 76;
+      -webkit-animation: outerDrawIn 0.5s ease-out forwards 0.3333333333333333s, appearIn 0.1s ease-out forwards 0.3333333333333333s;
+      animation: outerDrawIn 0.5s ease-out forwards 0.3333333333333333s, appearIn 0.1s ease-out forwards 0.3333333333333333s;
+      -webkit-animation-iteration-count: 1, 1;
+      animation-iteration-count: 1, 1;
+    }
+
+    .bsocdx {
+      opacity: 0;
+      stroke-dasharray: 76;
+      -webkit-animation: outerDrawIn 0.5s ease-out forwards 0.5333333333333333s, appearIn 0.1s ease-out forwards 0.5333333333333333s;
+      animation: outerDrawIn 0.5s ease-out forwards 0.5333333333333333s, appearIn 0.1s ease-out forwards 0.5333333333333333s;
+      -webkit-animation-iteration-count: 1, 1;
+      animation-iteration-count: 1, 1;
+    }
+
+    .jAZXmP {
+      opacity: 0;
+      stroke-dasharray: 76;
+      -webkit-animation: outerDrawIn 0.5s ease-out forwards 0.7333333333333334s, appearIn 0.1s ease-out forwards 0.7333333333333334s;
+      animation: outerDrawIn 0.5s ease-out forwards 0.7333333333333334s, appearIn 0.1s ease-out forwards 0.7333333333333334s;
+      -webkit-animation-iteration-count: 1, 1;
+      animation-iteration-count: 1, 1;
+    }
+
+    .hSeArx {
+      opacity: 0;
+      stroke-dasharray: 76;
+      -webkit-animation: outerDrawIn 0.5s ease-out forwards 0.9333333333333333s, appearIn 0.1s ease-out forwards 0.9333333333333333s;
+      animation: outerDrawIn 0.5s ease-out forwards 0.9333333333333333s, appearIn 0.1s ease-out forwards 0.9333333333333333s;
+      -webkit-animation-iteration-count: 1, 1;
+      animation-iteration-count: 1, 1;
+    }
+
+    .bVgqGk {
+      opacity: 0;
+      stroke-dasharray: 76;
+      -webkit-animation: outerDrawIn 0.5s ease-out forwards 1.1333333333333333s, appearIn 0.1s ease-out forwards 1.1333333333333333s;
+      animation: outerDrawIn 0.5s ease-out forwards 1.1333333333333333s, appearIn 0.1s ease-out forwards 1.1333333333333333s;
+      -webkit-animation-iteration-count: 1, 1;
+      animation-iteration-count: 1, 1;
+    }
+
+    .hEFqBt {
+      opacity: 0;
+      stroke-dasharray: 76;
+      -webkit-animation: outerDrawIn 0.5s ease-out forwards 1.3333333333333333s, appearIn 0.1s ease-out forwards 1.3333333333333333s;
+      animation: outerDrawIn 0.5s ease-out forwards 1.3333333333333333s, appearIn 0.1s ease-out forwards 1.3333333333333333s;
+      -webkit-animation-iteration-count: 1, 1;
+      animation-iteration-count: 1, 1;
+    }
+
+    .dzEKCM {
+      opacity: 0;
+      stroke-dasharray: 70;
+      -webkit-animation: innerDrawIn 1s ease-in-out forwards 1.3666666666666667s, appearIn 0.1s linear forwards 1.3666666666666667s;
+      animation: innerDrawIn 1s ease-in-out forwards 1.3666666666666667s, appearIn 0.1s linear forwards 1.3666666666666667s;
+      -webkit-animation-iteration-count: infinite, 1;
+      animation-iteration-count: infinite, 1;
+    }
+
+    .DYnPx {
+      opacity: 0;
+      stroke-dasharray: 70;
+      -webkit-animation: innerDrawIn 1s ease-in-out forwards 1.5333333333333332s, appearIn 0.1s linear forwards 1.5333333333333332s;
+      animation: innerDrawIn 1s ease-in-out forwards 1.5333333333333332s, appearIn 0.1s linear forwards 1.5333333333333332s;
+      -webkit-animation-iteration-count: infinite, 1;
+      animation-iteration-count: infinite, 1;
+    }
+
+    .hjPEAQ {
+      opacity: 0;
+      stroke-dasharray: 70;
+      -webkit-animation: innerDrawIn 1s ease-in-out forwards 1.7000000000000002s, appearIn 0.1s linear forwards 1.7000000000000002s;
+      animation: innerDrawIn 1s ease-in-out forwards 1.7000000000000002s, appearIn 0.1s linear forwards 1.7000000000000002s;
+      -webkit-animation-iteration-count: infinite, 1;
+      animation-iteration-count: infinite, 1;
+    }
+
+    #loading-wrapper {
+      position: absolute;
+      width: 100vw;
+      height: 100vh;
+      display: -webkit-box;
+      display: -webkit-flex;
+      display: -ms-flexbox;
+      display: flex;
+      -webkit-align-items: center;
+      -webkit-box-align: center;
+      -ms-flex-align: center;
+      align-items: center;
+      -webkit-box-pack: center;
+      -webkit-justify-content: center;
+      -ms-flex-pack: center;
+      justify-content: center;
+      -webkit-flex-direction: column;
+      -ms-flex-direction: column;
+      flex-direction: column;
+    }
+
+    .logo {
+      width: 75px;
+      height: 75px;
+      margin-bottom: 20px;
+      opacity: 0;
+      -webkit-animation: fadeIn 0.5s ease-out forwards;
+      animation: fadeIn 0.5s ease-out forwards;
+    }
+
+    .text {
+      font-size: 32px;
+      font-weight: 200;
+      text-align: center;
+      color: rgba(255, 255, 255, 0.6);
+      opacity: 0;
+      -webkit-animation: fadeIn 0.5s ease-out forwards;
+      animation: fadeIn 0.5s ease-out forwards;
+    }
+
+    .dGfHfc {
+      font-weight: 400;
+    }
+  </style>
+  <div id="loading-wrapper">
+    <svg class="logo" viewBox="0 0 128 128" xmlns:xlink="http://www.w3.org/1999/xlink">
+      <title>GraphQL Playground Logo</title>
+      <defs>
+        <linearGradient id="linearGradient-1" x1="4.86%" x2="96.21%" y1="0%" y2="99.66%">
+          <stop stop-color="#E00082" stop-opacity=".8" offset="0%"></stop>
+          <stop stop-color="#E00082" offset="100%"></stop>
+        </linearGradient>
+      </defs>
+      <g>
+        <rect id="Gradient" width="127.96" height="127.96" y="1" fill="url(#linearGradient-1)" rx="4"></rect>
+        <path id="Border" fill="#E00082" fill-rule="nonzero" d="M4.7 2.84c-1.58 0-2.86 1.28-2.86 2.85v116.57c0 1.57 1.28 2.84 2.85 2.84h116.57c1.57 0 2.84-1.26 2.84-2.83V5.67c0-1.55-1.26-2.83-2.83-2.83H4.67zM4.7 0h116.58c3.14 0 5.68 2.55 5.68 5.7v116.58c0 3.14-2.54 5.68-5.68 5.68H4.68c-3.13 0-5.68-2.54-5.68-5.68V5.68C-1 2.56 1.55 0 4.7 0z"></path>
+        <path class="bglIGM" x="64" y="28" fill="#fff" d="M64 36c-4.42 0-8-3.58-8-8s3.58-8 8-8 8 3.58 8 8-3.58 8-8 8" style="transform: translate(100px, 100px);"></path>
+        <path class="ksxRII" x="95.98500061035156" y="46.510000228881836" fill="#fff" d="M89.04 50.52c-2.2-3.84-.9-8.73 2.94-10.96 3.83-2.2 8.72-.9 10.95 2.94 2.2 3.84.9 8.73-2.94 10.96-3.85 2.2-8.76.9-10.97-2.94"
+          style="transform: translate(100px, 100px);"></path>
+        <path class="cWrBmb" x="95.97162628173828" y="83.4900016784668" fill="#fff" d="M102.9 87.5c-2.2 3.84-7.1 5.15-10.94 2.94-3.84-2.2-5.14-7.12-2.94-10.96 2.2-3.84 7.12-5.15 10.95-2.94 3.86 2.23 5.16 7.12 2.94 10.96"
+          style="transform: translate(100px, 100px);"></path>
+        <path class="Wnusb" x="64" y="101.97999572753906" fill="#fff" d="M64 110c-4.43 0-8-3.6-8-8.02 0-4.44 3.57-8.02 8-8.02s8 3.58 8 8.02c0 4.4-3.57 8.02-8 8.02"
+          style="transform: translate(100px, 100px);"></path>
+        <path class="bfPqf" x="32.03982162475586" y="83.4900016784668" fill="#fff" d="M25.1 87.5c-2.2-3.84-.9-8.73 2.93-10.96 3.83-2.2 8.72-.9 10.95 2.94 2.2 3.84.9 8.73-2.94 10.96-3.85 2.2-8.74.9-10.95-2.94"
+          style="transform: translate(100px, 100px);"></path>
+        <path class="edRCTN" x="32.033552169799805" y="46.510000228881836" fill="#fff" d="M38.96 50.52c-2.2 3.84-7.12 5.15-10.95 2.94-3.82-2.2-5.12-7.12-2.92-10.96 2.2-3.84 7.12-5.15 10.95-2.94 3.83 2.23 5.14 7.12 2.94 10.96"
+          style="transform: translate(100px, 100px);"></path>
+        <path class="iEGVWn" stroke="#fff" stroke-width="4" stroke-linecap="round" stroke-linejoin="round" d="M63.55 27.5l32.9 19-32.9-19z"></path>
+        <path class="bsocdx" stroke="#fff" stroke-width="4" stroke-linecap="round" stroke-linejoin="round" d="M96 46v38-38z"></path>
+        <path class="jAZXmP" stroke="#fff" stroke-width="4" stroke-linecap="round" stroke-linejoin="round" d="M96.45 84.5l-32.9 19 32.9-19z"></path>
+        <path class="hSeArx" stroke="#fff" stroke-width="4" stroke-linecap="round" stroke-linejoin="round" d="M64.45 103.5l-32.9-19 32.9 19z"></path>
+        <path class="bVgqGk" stroke="#fff" stroke-width="4" stroke-linecap="round" stroke-linejoin="round" d="M32 84V46v38z"></path>
+        <path class="hEFqBt" stroke="#fff" stroke-width="4" stroke-linecap="round" stroke-linejoin="round" d="M31.55 46.5l32.9-19-32.9 19z"></path>
+        <path class="dzEKCM" id="Triangle-Bottom" stroke="#fff" stroke-width="4" d="M30 84h70" stroke-linecap="round"></path>
+        <path class="DYnPx" id="Triangle-Left" stroke="#fff" stroke-width="4" d="M65 26L30 87" stroke-linecap="round"></path>
+        <path class="hjPEAQ" id="Triangle-Right" stroke="#fff" stroke-width="4" d="M98 87L63 26" stroke-linecap="round"></path>
+      </g>
+    </svg>
+    <div class="text">Loading
+      <span class="dGfHfc">GraphQL Playground</span>
+    </div>
+  </div>
+
+  <div id="root" />
+  <script type="text/javascript">
+    window.addEventListener('load', function (event) {
+
+      const loadingWrapper = document.getElementById('loading-wrapper');
+      loadingWrapper.classList.add('fadeOut');
+
+
+      const root = document.getElementById('root');
+      root.classList.add('playgroundIn');
+
+      GraphQLPlayground.init(root, {
+        // you can add more options here
+        'endpoint': '/graphql'
+      })
+    })
+  </script>
+</body>
+</html>

--- a/modules/service/src/main/scala/LocalSsoClient.scala
+++ b/modules/service/src/main/scala/LocalSsoClient.scala
@@ -1,0 +1,68 @@
+// Copyright (c) 2016-2021 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package lucuma.sso.service
+
+import cats.data._
+import cats.effect._
+import cats.syntax.all._
+import lucuma.sso.client.SsoClient
+import lucuma.sso.client.SsoClient.AbstractSsoClient
+import org.http4s._
+import org.http4s.headers.Authorization
+import org.http4s.Credentials.Token
+import org.http4s.util.CaseInsensitiveString
+import lucuma.sso.client.SsoJwtReader
+import lucuma.sso.client.ApiKey
+import lucuma.core.model.{ User, StandardUser }
+import lucuma.sso.service.database.Database
+
+/**
+ * Constructor for an SsoClient that runs locally, which we need for endpoints that are going to be
+ * authenticated normally.
+ */
+object LocalSsoClient {
+
+  def apply[F[_]: Sync](
+    jwtReader: SsoJwtReader[F],
+    dbPool:    Resource[F, Database[F]]
+  ): SsoClient[F, User] =
+    new AbstractSsoClient[F, User] {
+
+      val Bearer = CaseInsensitiveString("Bearer")
+
+      def fetchApiUser(apiKey: ApiKey): F[Option[StandardUser]] =
+        dbPool.use(_.findStandardUserFromApiKey(apiKey))
+
+      def getApiKey(bearerAuthorization: String): Option[ApiKey] =
+        ApiKey.fromString.getOption(bearerAuthorization)
+
+      def getApiUser(bearerAuthorization: String): F[Option[StandardUser]] =
+        getApiKey(bearerAuthorization).flatTraverse(fetchApiUser)
+
+      def getJwtInfo(bearerAuthorization: String): F[Option[User]] = {
+        for {
+          claim <- jwtReader.decodeClaim(bearerAuthorization)
+          user  <- claim.getUser.liftTo[F]
+        } yield user
+      } .attempt.map(_.toOption)
+
+      def getUserInfo(bearerAuthorization: String): F[Option[User]] =
+        (OptionT(getApiUser(bearerAuthorization).widen[Option[User]]) <+>
+         OptionT(getJwtInfo(bearerAuthorization))).value
+
+      def get(authorization: Authorization): F[Option[User]] =
+        authorization.credentials match {
+          case Token(Bearer, ba) => getUserInfo(ba)
+          case _                 => none.pure[F]
+        }
+
+      def find(req: Request[F]): F[Option[User]] =
+        req.headers.get(Authorization) match {
+          case Some(a) => get(a)
+          case None    => none.pure[F]
+      }
+
+    }
+
+}

--- a/modules/service/src/main/scala/database/Codecs.scala
+++ b/modules/service/src/main/scala/database/Codecs.scala
@@ -53,3 +53,5 @@ trait Codecs {
     text.map(ApiKey.fromString.getOption).emap(_.toRight("Invalid API Key"))
 
 }
+
+object Codecs extends Codecs

--- a/modules/service/src/main/scala/graphql/SsoMapping.scala
+++ b/modules/service/src/main/scala/graphql/SsoMapping.scala
@@ -15,22 +15,9 @@ import edu.gemini.grackle.skunk.SkunkMapping
 import edu.gemini.grackle.Schema
 import scala.io.Source
 import scala.util.Using
-import org.tpolecat.sourcepos.SourcePos
-import edu.gemini.grackle.NamedType
-import edu.gemini.grackle.Directive
 import lucuma.core.model.StandardUser
 
 object SsoMapping {
-
-  // Does this make sense?
-  implicit class SchemaOps(self: Schema) {
-    def ++(other: Schema)(implicit sp: SourcePos): Schema =
-      new Schema {
-        val pos: SourcePos = sp
-        def types: List[NamedType] = self.types ++ other.types
-        def directives: List[Directive] = self.directives ++ other.directives
-      }
-  }
 
   // In principle this is a pure operation because resources are constant values, but the potential
   // for error in dev is high and it's nice to handle failures in `F`.

--- a/modules/service/src/main/scala/graphql/SsoMapping.scala
+++ b/modules/service/src/main/scala/graphql/SsoMapping.scala
@@ -1,0 +1,125 @@
+package lucuma.sso.service.graphql
+
+import skunk._
+import cats.effect._
+import cats.syntax.all._
+import edu.gemini.grackle.Predicate._
+import edu.gemini.grackle.Query._
+import edu.gemini.grackle.QueryCompiler
+import lucuma.core.model
+import lucuma.core.model.OrcidId
+import lucuma.core.model.Partner
+import lucuma.sso.service.database.RoleType
+import edu.gemini.grackle.skunk.SkunkMonitor
+import edu.gemini.grackle.skunk.SkunkMapping
+import edu.gemini.grackle.Schema
+import scala.io.Source
+import scala.util.Using
+import org.tpolecat.sourcepos.SourcePos
+import edu.gemini.grackle.NamedType
+import edu.gemini.grackle.Directive
+import lucuma.core.model.StandardUser
+
+object SsoMapping {
+
+  // Does this make sense?
+  implicit class SchemaOps(self: Schema) {
+    def ++(other: Schema)(implicit sp: SourcePos): Schema =
+      new Schema {
+        val pos: SourcePos = sp
+        def types: List[NamedType] = self.types ++ other.types
+        def directives: List[Directive] = self.directives ++ other.directives
+      }
+  }
+
+  // In principle this is a pure operation because resources are constant values, but the potential
+  // for error in dev is high and it's nice to handle failures in `F`.
+  def loadSchema[F[_]: Sync]: F[Schema] =
+    Sync[F].defer {
+      Using(Source.fromResource("Sso.graphql", getClass().getClassLoader())) { src =>
+        Schema(src.mkString).right.get // TODO
+      } .liftTo[F]
+    }
+
+  def apply[F[_]: Sync](
+    pool:    Resource[F, Session[F]],
+    monitor: SkunkMonitor[F],
+  ): F[StandardUser => SkunkMapping[F]] =
+    loadSchema[F].map { loadedSchema => user =>
+
+      new SkunkMapping[F](pool, monitor) with SsoTables[F] {
+
+        val schema: Schema = loadedSchema
+
+        val ApiKeyType   = schema.ref("ApiKey")
+        val QueryType    = schema.ref("Query")
+        val UserType     = schema.ref("User")
+        val UserIdType   = schema.ref("UserId")
+        val OrcidIdType  = schema.ref("OrcidId")
+        val RoleType     = schema.ref("Role")
+        val RoleIdType   = schema.ref("RoleId")
+        val RoleTypeType = schema.ref("RoleType")
+        val PartnerType  = schema.ref("Partner")
+
+        val typeMappings: List[TypeMapping] =
+          List(
+            ObjectMapping(
+              tpe = QueryType,
+              fieldMappings = List(
+                SqlRoot("user"),
+                SqlRoot("role"),
+              )
+            ),
+            ObjectMapping(
+              tpe = UserType,
+              fieldMappings = List(
+                SqlField("id", User.Id, key = true),
+                SqlField("orcidId", User.OrcidId),
+                SqlField("givenName", User.GivenName),
+                SqlField("familyName", User.FamilyName),
+                SqlField("creditName", User.CreditName),
+                SqlField("email", User.Email),
+                SqlObject("roles", Join(User.Id, Role.UserId)),
+                SqlObject("apiKeys", Join(User.Id, ApiKey.UserId)),
+              )
+            ),
+            ObjectMapping(
+              tpe = RoleType,
+              fieldMappings = List(
+                SqlField("id", Role.Id, key = true),
+                SqlField("type", Role.Type),
+                SqlField("partner", Role.Partner),
+                SqlAttribute("«unused»", Role.UserId),
+                SqlObject("user", Join(Role.UserId, User.Id)),
+              )
+            ),
+            ObjectMapping(
+              tpe = ApiKeyType,
+              fieldMappings = List(
+                SqlField("id", ApiKey.Id, key = true),
+                SqlAttribute("«unused»", ApiKey.UserId),
+                SqlAttribute("«unused»", ApiKey.RoleId),
+                SqlObject("user", Join(ApiKey.UserId, User.Id)),
+                SqlObject("role", Join(ApiKey.RoleId, Role.Id)),
+              )
+            ),
+            LeafMapping[model.User.Id](UserIdType),
+            LeafMapping[OrcidId](OrcidIdType),
+            LeafMapping[model.StandardRole.Id](RoleIdType),
+            LeafMapping[RoleType](RoleTypeType),
+            LeafMapping[Partner](PartnerType)
+          )
+
+        override val selectElaborator = new QueryCompiler.SelectElaborator(Map(
+          QueryType -> {
+            case Select("user", Nil, child) =>
+              Select("user", Nil, Unique(Eql(FieldPath(List("id")), Const(user.id)), child)).rightIor
+            case Select("role", Nil, child) =>
+              Select("role", Nil, Unique(Eql(FieldPath(List("id")), Const(user.role.id)), child)).rightIor
+          }
+        ))
+
+      }
+
+    }
+}

--- a/modules/service/src/main/scala/graphql/SsoMapping.scala
+++ b/modules/service/src/main/scala/graphql/SsoMapping.scala
@@ -1,3 +1,6 @@
+// Copyright (c) 2016-2021 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
 package lucuma.sso.service.graphql
 
 import skunk._

--- a/modules/service/src/main/scala/graphql/SsoTables.scala
+++ b/modules/service/src/main/scala/graphql/SsoTables.scala
@@ -1,3 +1,6 @@
+// Copyright (c) 2016-2021 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
 package lucuma.sso.service.graphql
 
 import edu.gemini.grackle.skunk.SkunkMapping

--- a/modules/service/src/main/scala/graphql/SsoTables.scala
+++ b/modules/service/src/main/scala/graphql/SsoTables.scala
@@ -1,0 +1,42 @@
+package lucuma.sso.service.graphql
+
+import edu.gemini.grackle.skunk.SkunkMapping
+import lucuma.sso.service.database.Codecs
+import skunk.codec.all._
+import lucuma.sso.service.database.RoleType
+import io.circe
+import io.circe.Json
+
+trait SsoTables[F[_]] extends Codecs { this: SkunkMapping[F] =>
+
+  implicit val RoleTypeEncoder: circe.Encoder[RoleType] =
+    rt => Json.fromString(rt.entryName.toUpperCase())
+
+  class TableDef(name: String) {
+    def col(colName: String, codec: Codec[_]): ColumnRef =
+      ColumnRef(name, colName, codec)
+  }
+
+  object User extends TableDef("lucuma_user") {
+    val Id         = col("user_id", user_id)
+    val OrcidId    = col("orcid_id", orcid_id)
+    val GivenName  = col("orcid_given_name", varchar.opt)
+    val FamilyName = col("orcid_family_name", varchar.opt)
+    val CreditName = col("orcid_credit_name", varchar.opt)
+    val Email      = col("orcid_email", varchar.opt)
+  }
+
+  object Role extends TableDef("lucuma_role") {
+    val Id      = col("role_id", role_id)
+    val Type    = col("role_type", role_type)
+    val Partner = col("role_ngo", partner.opt)
+    val UserId  = col("user_id", user_id)
+  }
+
+  object ApiKey extends TableDef("lucuma_api_key") {
+    val Id     = col("api_key_id", varchar)
+    val UserId = col("user_id", user_id)
+    val RoleId = col("role_id", role_id)
+  }
+
+}

--- a/modules/service/src/test/scala/CorsSuite.scala
+++ b/modules/service/src/test/scala/CorsSuite.scala
@@ -20,6 +20,7 @@ object CorsSuite extends SsoSuite {
         jwtWriter = null,
         publicUri = uri"http://unused",
         cookies   = null,
+        graphQL   = null,
       )
     )
 

--- a/modules/service/src/test/scala/GraphQLSuite.scala
+++ b/modules/service/src/test/scala/GraphQLSuite.scala
@@ -1,0 +1,100 @@
+// Copyright (c) 2016-2021 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package lucuma.sso.service
+
+import cats.effect._
+import cats.implicits._
+import lucuma.sso.service.simulator.SsoSimulator
+import org.http4s.headers.Location
+import org.http4s.Request
+import org.http4s.Method
+import org.http4s.headers.Authorization
+import org.http4s.util.CaseInsensitiveString
+import org.http4s.Credentials
+import org.http4s.Headers
+import lucuma.core.util.Gid
+import org.http4s.QueryParamEncoder
+import eu.timepit.refined.auto._
+import lucuma.sso.client.ApiKey
+import io.circe.Json
+import io.circe.literal._
+import org.http4s.circe._
+
+object GraphQLSuite extends SsoSuite with Fixture {
+
+  implicit def gidQueryParamEncoder[A: Gid]: QueryParamEncoder[A] =
+    QueryParamEncoder[String].contramap(Gid[A].fromString.reverseGet)
+
+  def testQueryAsBob(query: String, expected: Json) =
+    SsoSimulator[IO].use { case (_, sim, sso, reader, _) =>
+      val stage1  = (SsoRoot / "auth" / "v1" / "stage1").withQueryParam("state", ExploreRoot)
+      for {
+
+        // Log in as Bob
+        redir  <- sso.get(stage1)(_.headers.get(Location).map(_.uri).get.pure[IO])
+        stage2 <- sim.authenticate(redir, Bob, None)
+        _      <- sso.get(stage2)(CookieReader[IO].getSessionToken) // ensure we have our cookie
+        jwt    <- sso.expect[String](Request[IO](method = Method.POST, uri = SsoRoot / "api" / "v1" / "refresh-token"))
+        user   <- reader.decodeStandardUser(jwt)
+
+        // Create an API Key
+        apiKey <- sso.expect[ApiKey](
+          Request[IO](
+            method  = Method.POST,
+            uri     = (SsoRoot / "api" / "v1" / "create-api-key").withQueryParam("role", user.role.id),
+            headers = Headers.of(Authorization(Credentials.Token(CaseInsensitiveString("Bearer"), jwt))),
+          )
+        )
+
+        // Run a query!
+        result <- sso.expect[Json](
+          Request[IO](
+            method  = Method.POST,
+            uri     = SsoRoot / "graphql",
+            headers = Headers.of(Authorization(Credentials.Token(CaseInsensitiveString("Bearer"), ApiKey.fromString.reverseGet(apiKey)))),
+          ).withEntity(
+            Json.obj(
+              "query" -> Json.fromString(query)
+            )
+          )
+        )
+
+      } yield expect(result == expected)
+    } .onError(e => IO(println(e)))
+
+
+  simpleTest("Query current role.") {
+    testQueryAsBob(
+      query = """
+        query {
+          role {
+            type
+            partner
+            user {
+              givenName
+              familyName
+              creditName
+              email
+            }
+          }
+        }
+      """,
+      expected = json"""{
+        "data" : {
+          "role" : {
+            "type" : "PI",
+            "partner" : null,
+            "user" : {
+              "givenName" : "Bob",
+              "familyName" : "Dobbs",
+              "creditName" : null,
+              "email" : "bob@dobbs.com"
+            }
+          }
+        }
+      }"""
+    )
+  }
+
+}


### PR DESCRIPTION
This adds a Query-only GraphQL endpoint for authenticated users under `/graphql` and playground under `/playground.html`. 

Currently all you can see is your own user record, so there's not a lot of point going to the database (all this information is in memory). But I wanted to see how it works and we will definitely need it for users with higher access than normal PIs because these users will be able to see/update other users' records.

In order to use the playground you need an API key and the only way to get one at the moment is via the REST API or by hitting the database directly. Let me know if you want one.
