### PR TITLE
createApiKey

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,7 +62,12 @@ extension](https://devcenter.heroku.com/articles/dyno-metadata) to get the full 
 
 ### Login
 
-The user must be allowed to choose to log in with ORCID or log in as a guest.
+The user must be allowed to choose to log in with ORCID (as a standard user) or log in as a guest.
+Service users are not interactive users and cannot log in.
+
+#### Login Roles for Standard Users
+Standard users will always be logged in
+under a PI role. If the user has no such role (possible but unusual) it will be created. The user can later switch to a different role (see **Set Role** below) and this choice will be peristed in the refresh token. Associating the role with the refresh tokan allows a user to be logged in under several roles at the same time, in different browser sessions.
 
 #### Guest Login
 

--- a/modules/service/src/main/resources/Sso.graphql
+++ b/modules/service/src/main/resources/Sso.graphql
@@ -7,6 +7,10 @@ type Query {
   role: Role!
 }
 
+type Mutation {
+  createApiKey(role: RoleId!): String!
+}
+
 type User {
   id:           UserId!
   orcidId:      OrcidId!

--- a/modules/service/src/main/scala/graphql/ComputeMapping.scala
+++ b/modules/service/src/main/scala/graphql/ComputeMapping.scala
@@ -1,0 +1,40 @@
+// Copyright (c) 2016-2021 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package lucuma.sso.service.graphql
+
+import cats.syntax.all._
+import edu.gemini.grackle.Cursor
+import edu.gemini.grackle.Query
+import edu.gemini.grackle.Result
+import edu.gemini.grackle.Type
+import edu.gemini.grackle.circe.CirceMapping
+import io.circe.{ Encoder, Json }
+import org.tpolecat.sourcepos.SourcePos
+
+trait ComputeMapping[F[_]] { this: CirceMapping[F] =>
+
+  /** A RootMapping that computes a result directly. */
+  sealed abstract case class ComputeRoot[A] private (
+    fieldName: String,
+    tpe: Type,
+    pos: SourcePos,
+    run: Cursor.Env => F[Result[Json]],
+  ) extends RootMapping {
+    def cursor(query: Query, env: Cursor.Env, resultName: Option[String]): fs2.Stream[F,Result[(Query, Cursor)]] =
+        fs2.Stream.eval(run(env)).map { r => r.map(a => (query, CirceCursor(Cursor.Context(fieldName, resultName, tpe), a, None, env))) }
+    def mutation: Mutation = Mutation.None
+    def withParent(tpe: Type): RootMapping = this
+  }
+
+  object ComputeRoot {
+    /** Construct a `ComputeRoot` for the specified field and type. */
+    def apply[A](fieldName: String, tpe: Type, run: Cursor.Env => F[Result[A]])(
+      implicit pos: SourcePos,
+               enc: Encoder[A]
+    ): ComputeRoot[A] =
+      new ComputeRoot[A](fieldName, tpe, pos, e => run(e).map(_.map(enc(_)))) {}
+  }
+
+}
+

--- a/modules/service/src/main/scala/graphql/package.scala
+++ b/modules/service/src/main/scala/graphql/package.scala
@@ -1,0 +1,24 @@
+// Copyright (c) 2016-2021 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package lucuma.sso.service
+
+import cats.data.Ior
+import cats.data.NonEmptyChain
+
+package object graphql {
+
+  implicit class MoreOptionOps[A](self: Option[A]) {
+    def toRightIorNec[E](e: => E): Ior[NonEmptyChain[E], A] =
+      self match {
+        case Some(a) => Ior.Right(a)
+        case None    => Ior.Left(NonEmptyChain.of(e))
+      }
+  }
+
+  implicit class MoreIdOps[A](self: A) {
+    def leftIorNec[B]: Ior[NonEmptyChain[A], B] =
+      Ior.Left(NonEmptyChain.of(self))
+  }
+
+}


### PR DESCRIPTION
This adds a `createApiKey` mutation to the GraphQL interface, mostly just to see how to do it. Will be adding more interesting mutations soon.