### PR TITLE
deleteApiKey

### DIFF
--- a/modules/backend-client/src/main/scala/ApiKey.scala
+++ b/modules/backend-client/src/main/scala/ApiKey.scala
@@ -6,9 +6,7 @@ package lucuma.sso.client
 import cats.Order
 import cats.effect.Concurrent
 import cats.implicits._
-import eu.timepit.refined._
 import eu.timepit.refined.cats._
-import eu.timepit.refined.numeric.Positive
 import eu.timepit.refined.types.numeric.PosLong
 import monocle.Prism
 import org.http4s.{ DecodeResult, EntityDecoder, EntityEncoder, MalformedMessageBodyFailure }
@@ -25,20 +23,31 @@ import org.http4s.QueryParamEncoder
  * 10d.3b9e2adc5bffdac72f487a2760061bcfebc44037b69f2085c9a1ba10aa5d2d338421fc0d79f45cfd07666617ac4e2c89
  * }}}
  */
-final case class ApiKey(id: PosLong, body: String)
+final case class ApiKey(id: ApiKey.Id, body: String)
 object ApiKey {
+
+  type Id = PosLong
+  object Id {
+
+    /** Id from hex string. */
+    val fromString: Prism[String, Id] =
+      Prism[String, Id] { sid =>
+        Either.catchOnly[NumberFormatException](java.lang.Long.parseLong(sid, 16)).flatMap { n =>
+          PosLong.from(n)
+        } .toOption
+      } { id =>
+        id.value.toHexString
+      }
+
+  }
 
   private val R: Regex =
     raw"^([0-9a-f]{3,})\.([0-9a-f]{96})$$".r
 
   val fromString: Prism[String, ApiKey] =
     Prism[String, ApiKey] {
-      case R(sid, body) =>
-        for {
-          signed <- Either.catchOnly[NumberFormatException](java.lang.Long.parseLong(sid, 16)).toOption
-          pos    <- refineV[Positive](signed).toOption
-        } yield ApiKey(pos, body)
-      case _ => None
+      case R(sid, body) => Id.fromString.getOption(sid).map(ApiKey(_, body))
+      case _            => None
      } { k =>
       s"${k.id.value.toHexString}.${k.body}"
     }

--- a/modules/service/src/main/resources/Sso.graphql
+++ b/modules/service/src/main/resources/Sso.graphql
@@ -8,7 +8,13 @@ type Query {
 }
 
 type Mutation {
+
+  "Create and return an API key for the specified role, if owned by the current user."
   createApiKey(role: RoleId!): String!
+
+  "Delete the specified API key, if owned by the current user. Returns the constant value `true`."
+  deleteApiKey(id: ApiKeyId!): Boolean!
+
 }
 
 type User {
@@ -30,7 +36,7 @@ type Role {
 }
 
 type ApiKey {
-  id:   Int!
+  id:   ApiKeyId!
   user: User!
   role: Role!
 }
@@ -38,6 +44,7 @@ type ApiKey {
 scalar UserId
 scalar OrcidId
 scalar RoleId
+scalar ApiKeyId
 
 enum RoleType { PI NGO STAFF ADMIN }
 enum Partner { AR BR CA CL KR UH US }

--- a/modules/service/src/test/scala/ApiKeySuite.scala
+++ b/modules/service/src/test/scala/ApiKeySuite.scala
@@ -80,7 +80,7 @@ object ApiKeySuite extends SsoSuite with Fixture {
         apiKey <- db.use(_.createApiKey(user.role.id))
 
         // Delete it
-        _      <- db.use(_.deleteApiKey(apiKey.id))
+        _      <- db.use(_.deleteApiKey(apiKey.id, Some(user.id)))
 
         // Try to redeem it, should fail
         user2  <- db.use(_.findStandardUserFromApiKey(apiKey))


### PR DESCRIPTION
This adds a GraphQL mutation for deleting API keys by Id. Also improves tracing for the GraphQL endpoint and adds a prism for String <-> ApiKey.Id