### PR TITLE
set-role

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,13 +109,10 @@ under a PI role. If the user has no such role (possible but unusual) it will be 
 
 ### Set Role
 
-> This is not implemented yet.
-
-- Post to `/api/v1/setRole?role=<role-id>` to switch the user's current role.
-  - Be sure to pass the `Authorization` header.
+- GET `/auth/v1/set-role?role=<role-id>` to start a new session with the same user in a different role (taken from the user's `otherRoles` collection).
+  - This will set a new session cookie.
   - The response body will contain a new JWT.
-    - Continue with **Normal Operation** above.
-
+  - Continue with **Normal Operation** above.
 
 ## Back-End Service Workflow
 
@@ -144,7 +141,8 @@ It is possible to implement authentication as a middleware, but this makes compo
 
 ## Local Development QuickStart
 
-Edit `/etc/hosts` to add `local.lucuma.xyz` as an alias of localhost.
+- Step 1 is `chmod 0600 test-cert/*`
+- Edit `/etc/hosts` to add `local.lucuma.xyz` as an alias of localhost.
 
 ```
 127.0.0.1       localhost local.lucuma.xyz

--- a/modules/service/src/test/scala/SetRoleSuite.scala
+++ b/modules/service/src/test/scala/SetRoleSuite.scala
@@ -1,0 +1,46 @@
+// Copyright (c) 2016-2023 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package lucuma.sso.service
+
+import cats.effect._
+import cats.implicits._
+import lucuma.core.model._
+import lucuma.sso.service.simulator.SsoSimulator
+import org.http4s.headers.Location
+import lucuma.sso.service.database.RoleRequest
+
+object SetRoleSuite extends SsoSuite with Fixture with FlakyTests {
+
+  def setRole(rid: StandardRole.Id)  = 
+    (SsoRoot / "auth" / "v1" / "set-role").withQueryParam("role", rid.toString)
+
+  test("Set role.") {
+    SsoSimulator[IO].use { case (db, sim, sso, _, _) =>
+      val stage1  = (SsoRoot / "auth" / "v1" / "stage1").withQueryParam("state", ExploreRoot)
+      for {
+
+        // Log in as Bob, who is new.
+        redir  <- sso.get(stage1)(_.headers.get[Location].map(_.uri).get.pure[IO])
+        stage2 <- sim.authenticate(redir, Bob, None)
+        tok1   <- sso.get(stage2)(CookieReader[IO].getSessionToken)
+        user1  <- db.use(_.getStandardUserFromToken(tok1))
+
+        // Add an Admin role for Bob
+        rid    <- db.use(_.canonicalizeRole(user1, RoleRequest.Admin))
+
+        // Switch the role
+        tok2   <- sso.get(setRole(rid))(CookieReader[IO].getSessionToken)
+        user2  <- db.use(_.getStandardUserFromToken(tok2))
+
+      } yield expect(
+        user1.role.access === Access.Pi &&
+        user2.role.access === Access.Admin &&
+        user1.id === user2.id &&
+        user2.role.id === rid &&
+        user2.otherRoles.contains(user1.role)
+      )
+    }
+  }
+
+}

--- a/modules/service/src/test/scala/SetRoleSuite.scala
+++ b/modules/service/src/test/scala/SetRoleSuite.scala
@@ -6,9 +6,9 @@ package lucuma.sso.service
 import cats.effect._
 import cats.implicits._
 import lucuma.core.model._
+import lucuma.sso.service.database.RoleRequest
 import lucuma.sso.service.simulator.SsoSimulator
 import org.http4s.headers.Location
-import lucuma.sso.service.database.RoleRequest
 
 object SetRoleSuite extends SsoSuite with Fixture with FlakyTests {
 


### PR DESCRIPTION
This adds an endpoint that starts a new session for a user, under a different role. Clients can hit this endpoint to get a new session token and JWT.