### PR TITLE
loosen email requirements

### DIFF
--- a/modules/service/src/main/scala/orcid/OrcidPerson.scala
+++ b/modules/service/src/main/scala/orcid/OrcidPerson.scala
@@ -16,7 +16,9 @@ case class OrcidPerson(
 ) {
 
   def primaryEmail: Option[OrcidEmail] =
-    emails.find(_.primary)
+    emails.find(_.primary)  orElse
+    emails.find(_.verified) orElse
+    emails.headOption
 
 }
 


### PR DESCRIPTION
Andy's email address wasn't showing up because he didn't have an email address marked as "primary". This loosens the rules to prefer the primary email, if any, or else any verified email, or else any email at all.